### PR TITLE
Remove the doBenchmark flag

### DIFF
--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -72,10 +72,6 @@ source-repository    head
   type:              git
   location:          git@github.com/qfpl/waargonaut.git
 
-flag dobenchmark
-     description:    Enable benchmark suite
-     default:        False
-
 library
   -- Modules included in this executable, other than Main.
   exposed-modules:     Waargonaut.Types.Whitespace
@@ -182,11 +178,6 @@ test-suite waarg-tests
   default-language:    Haskell2010
 
 benchmark criterion
-  if flag(dobenchmark)
-    buildable:           True
-  else
-    buildable:           False
-
   other-modules:       ConvenientFlatSurface
 
   default-language:    Haskell2010


### PR DESCRIPTION
This fixes the build on GHC 7.10

Users building with cabal can build with `--disable-benchmarks` to avoid the benchmark dependencies (this is the default) and it looks like you have some nix set up to avoid building them too. The flag shouldn't be necessary.