### PR TITLE
Remove unnecessary uses of try in parsers

### DIFF
--- a/src/Waargonaut/Types/JChar.hs
+++ b/src/Waargonaut/Types/JChar.hs
@@ -77,7 +77,6 @@ import           Waargonaut.Types.Whitespace (Whitespace (..),
                                               _WhitespaceChar)
 
 import           Text.Parser.Char            (CharParsing, char, satisfy)
-import           Text.Parser.Combinators     (try)
 
 -- $setup
 -- >>> :set -XOverloadedStrings
@@ -428,7 +427,7 @@ parseJChar ::
   (CharParsing f, HeXaDeCiMaL digit) =>
   f ( JChar digit )
 parseJChar = asum
-  [ EscapedJChar <$> try parseJCharEscaped
+  [ EscapedJChar <$> parseJCharEscaped
   , UnescapedJChar <$> parseJCharUnescaped
   ]
 

--- a/src/Waargonaut/Types/JNumber.hs
+++ b/src/Waargonaut/Types/JNumber.hs
@@ -64,7 +64,7 @@ import           Data.Digit              (DecDigit)
 import qualified Data.Digit              as D
 
 import           Text.Parser.Char        (CharParsing, char)
-import           Text.Parser.Combinators (many, optional, try)
+import           Text.Parser.Combinators (many, optional)
 
 import           Data.ByteString.Builder (Builder)
 import qualified Data.ByteString.Builder as BB
@@ -273,7 +273,7 @@ parseJInt ::
   f JInt
 parseJInt =
   asum [
-    JZero <$ try (char '0')
+    JZero <$ char '0'
   , JIntInt <$> D.parseDecimalNoZero <*> many D.parseDecimal
   ]
 
@@ -304,7 +304,7 @@ parseE ::
   f E
 parseE =
   asum [
-    Ee <$ try (char 'e')
+    Ee <$ char 'e'
   , EE <$ char 'E'
   ]
 


### PR DESCRIPTION
`try` is only necessary if the first parser will consume at least one character before failing and you still want to try the second parser.

As far as I can tell, these should all fail on the first character so `try` shouldn't be necessary (although maybe I'm wrong)