### PR TITLE
Rework Encoder types to be more in line with Decoder.

### DIFF
--- a/src/Waargonaut/Encode.hs
+++ b/src/Waargonaut/Encode.hs
@@ -1,25 +1,23 @@
-{-# LANGUAGE FlexibleContexts           #-}
-{-# LANGUAGE FlexibleInstances          #-}
-{-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE MultiParamTypeClasses      #-}
-{-# LANGUAGE NoImplicitPrelude          #-}
-{-# LANGUAGE ScopedTypeVariables        #-}
-{-# LANGUAGE TupleSections              #-}
-{-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE FlexibleContexts      #-}
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE TupleSections         #-}
+{-# LANGUAGE TypeFamilies          #-}
 -- | Types and functions to encode your data types to 'Json'.
 module Waargonaut.Encode
   (
     -- * Encoder type
-    Encoder' (..)
-  , Encoder (..)
+    Encoder (..)
+  , Encoder'
 
     -- * Creation
   , encodeA
   , encodePureA
   , runPureEncoder
-  , encodeToJson
 
-    -- * Pure Encoders
+    -- * Provided encoders
   , int
   , bool
   , text
@@ -39,11 +37,13 @@ module Waargonaut.Encode
   , intAt
   , textAt
   , boolAt
-  , foldableAt
+  , traversableAt
   , listAt
   , nonemptyAt
+  , encAt
+  , keyValuesAsObj
 
-    -- * Applicative Encoders
+    -- * Encoders specialised to Identity
   , int'
   , bool'
   , text'
@@ -54,21 +54,26 @@ module Waargonaut.Encode
   , traversable'
   , nonempty'
   , list'
+  , atKey'
+  , mapLikeObj'
   , mapToObj'
+  , keyValuesAsObj'
   , json'
 
   ) where
 
-import           Control.Applicative        (Applicative (..))
+import           Control.Applicative        (Applicative (..), (<$>))
 import           Control.Category           (id, (.))
 import           Control.Lens               (AReview, At, Index, IxValue,
                                              Rewrapped, Wrapped (..), at, cons,
                                              iso, ( # ), (?~), _Empty, _Wrapped)
-import           Prelude                    (Bool, Int)
+import qualified Control.Lens               as L
 
-import           Data.Foldable              (Foldable, foldr)
-import           Data.Function              (const, flip, ($))
-import           Data.Functor               (fmap)
+import           Prelude                    (Bool, Int, Monad)
+
+import           Data.Foldable              (Foldable, foldr, foldrM)
+import           Data.Function              (const, flip, ($), (&))
+import           Data.Functor               (Functor, fmap)
 import           Data.Functor.Contravariant (Contravariant (..))
 import           Data.Functor.Identity      (Identity (..))
 import           Data.Traversable           (Traversable, traverse)
@@ -91,64 +96,51 @@ import qualified Data.Map                   as Map
 import           Data.Text                  (Text)
 
 import           Waargonaut                 (waargonautBuilder)
-import           Waargonaut.Types           (AsJType (..), Json,
-                                             MapLikeObj (..), WS, textToJString,
-                                             wsRemover, _JNumberInt)
+import           Waargonaut.Types           (AsJType (..), JAssoc (..), JObject,
+                                             Json, MapLikeObj (..), WS,
+                                             textToJString, wsRemover,
+                                             _JNumberInt)
 
 -- |
 -- Define an "encoder" as a function from some @a@ to some 'Json' with the
 -- allowance for some context @f@.
 --
-newtype Encoder' f a = Encoder'
+newtype Encoder f a = Encoder
   { runEncoder :: a -> f Json
   }
 
-instance (Encoder' f a) ~ t => Rewrapped (Encoder' f a) t
+instance (Encoder f a) ~ t => Rewrapped (Encoder f a) t
 
-instance Wrapped (Encoder' f a) where
-  type Unwrapped (Encoder' f a) = a -> f Json
-  _Wrapped' = iso runEncoder Encoder'
+instance Wrapped (Encoder f a) where
+  type Unwrapped (Encoder f a) = a -> f Json
+  _Wrapped' = iso runEncoder Encoder
 
-instance Contravariant (Encoder' f) where
-  contramap f (Encoder' g) = Encoder' (g . f)
+instance Contravariant (Encoder f) where
+  contramap f (Encoder g) = Encoder (g . f)
 
 -- |
 -- As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
-newtype Encoder a = Encoder
-  { unEncoder :: Encoder' Identity a
-  }
-  deriving (Contravariant)
-
-instance (Encoder a) ~ t => Rewrapped (Encoder a) t
-
-instance Wrapped (Encoder a) where
-  type Unwrapped (Encoder a) = Encoder' Identity a
-  _Wrapped' = iso unEncoder Encoder
+type Encoder' = Encoder Identity
 
 -- | Create an 'Encoder'' for 'a' by providing a function from 'a -> f Json'.
-encodeA :: (a -> f Json) -> Encoder' f a
-encodeA = Encoder'
+encodeA :: (a -> f Json) -> Encoder f a
+encodeA = Encoder
 
 -- | As 'encodeA' but specialised to 'Identity' when the additional flexibility
 -- isn't needed.
-encodePureA :: (a -> Json) -> Encoder a
-encodePureA f = Encoder $ encodeA (Identity . f)
-
-encodeToJson :: Encoder a -> a -> Json
-encodeToJson enc = runIdentity . runEncoder (unEncoder enc)
+encodePureA :: (a -> Json) -> Encoder' a
+encodePureA f = encodeA (Identity . f)
 
 -- | Run the given 'Encoder' to produce a lazy 'ByteString'.
-runPureEncoder :: Encoder a -> a -> ByteString
+runPureEncoder :: Encoder' a -> a -> ByteString
 runPureEncoder enc = BB.toLazyByteString
   . waargonautBuilder wsRemover
-  . encodeToJson enc
+  . runIdentity
+  . runEncoder enc
 
 -- | 'Encoder'' for a Waargonaut 'Json' data structure
-json' :: Applicative f => Encoder' f Json
-json' = encodeA pure
-
-json :: Encoder Json
-json = Encoder json'
+json :: Applicative f => Encoder f Json
+json = encodeA pure
 
 encJ
   :: ( Monoid t
@@ -156,115 +148,138 @@ encJ
      )
   => AReview Json (b, t)
   -> (a -> b)
-  -> Encoder' f a
+  -> Encoder f a
 encJ c f =
   encodeA (pure . (c #) . (,mempty) . f)
 
 -- | Encode an 'Int'
-int' :: Applicative f => Encoder' f Int
-int' = encJ _JNum (_JNumberInt #)
+int :: Applicative f => Encoder f Int
+int = encJ _JNum (_JNumberInt #)
 
 -- | Encode a 'Bool'
-bool' :: Applicative f => Encoder' f Bool
-bool' = encJ _JBool id
+bool :: Applicative f => Encoder f Bool
+bool = encJ _JBool id
 
 -- | Encode a 'Text'
-text' :: Applicative f => Encoder' f Text
-text' = encJ _JStr textToJString
+text :: Applicative f => Encoder f Text
+text = encJ _JStr textToJString
 
 -- | Encode an explicit 'null'.
-null' :: Applicative f => Encoder' f ()
-null' = encodeA $ const (pure $ _JNull # mempty)
+null :: Applicative f => Encoder f ()
+null = encodeA $ const (pure $ _JNull # mempty)
 
 -- | Encode a 'Maybe' value, using the provided 'Encoder''s to handle the
 -- different choices.
-maybe'
+maybe
   :: Applicative f
-  => Encoder' f ()
-  -> Encoder' f a
-  -> Encoder' f (Maybe a)
-maybe' encN = encodeA
+  => Encoder f ()
+  -> Encoder f a
+  -> Encoder f (Maybe a)
+maybe encN = encodeA
   . Maybe.maybe (runEncoder encN ())
   . runEncoder
 
 -- | Encode a 'Maybe a' to either 'Encoder a' or 'null'
-maybeOrNull'
-  :: Applicative f
-  => Encoder' f a
-  -> Encoder' f (Maybe a)
-maybeOrNull' =
-  maybe' null'
-
--- | Encode an 'Either' value using the given 'Encoder's
-either'
-  :: Applicative f
-  => Encoder' f a
-  -> Encoder' f b
-  -> Encoder' f (Either a b)
-either' eA = encodeA
-  . Either.either (runEncoder eA)
-  . runEncoder
-
--- | Encode a 'NonEmpty' list
-nonempty'
-  :: Applicative f
-  => Encoder' f a
-  -> Encoder' f (NonEmpty a)
-nonempty' =
-  traversable'
-
--- | Encode a standard Haskell list
-list'
-  :: Applicative f
-  => Encoder' f a
-  -> Encoder' f [a]
-list' =
-  traversable'
-
-int :: Encoder Int
-int = Encoder int'
-
-bool :: Encoder Bool
-bool = Encoder bool'
-
-text :: Encoder Text
-text = Encoder text'
-
-null :: Encoder ()
-null = Encoder null'
-
-maybe
-  :: Encoder ()
-  -> Encoder a
-  -> Encoder (Maybe a)
-maybe a = Encoder
-  . maybe' (unEncoder a)
-  . unEncoder
-
 maybeOrNull
-  :: Encoder a
-  -> Encoder (Maybe a)
+  :: Applicative f
+  => Encoder f a
+  -> Encoder f (Maybe a)
 maybeOrNull =
   maybe null
 
+-- | Encode an 'Either' value using the given 'Encoder's
 either
-  :: Encoder a
-  -> Encoder b
-  -> Encoder (Either a b)
-either a = Encoder
-  . either' (unEncoder a)
-  . unEncoder
+  :: Applicative f
+  => Encoder f a
+  -> Encoder f b
+  -> Encoder f (Either a b)
+either eA = encodeA
+  . Either.either (runEncoder eA)
+  . runEncoder
 
+-- | Encode some 'Traversable' of 'a' into a JSON array.
+traversable
+  :: ( Applicative f
+     , Traversable t
+     )
+  => Encoder f a
+  -> Encoder f (t a)
+traversable = encodeWithInner
+  (\xs -> _JArr # (_Wrapped # foldr cons mempty xs, mempty))
+
+-- | Encode a 'Map' in a JSON object.
+mapToObj
+  :: Applicative f
+  => Encoder f a
+  -> (k -> Text)
+  -> Encoder f (Map k a)
+mapToObj encodeVal kToText =
+  let
+    mapToCS = Map.foldrWithKey (\k v -> at (kToText k) ?~ v) (_Empty # ())
+  in
+    encodeWithInner (\xs -> _JObj # (fromMapLikeObj $ mapToCS xs, mempty)) encodeVal
+
+-- | Encode a 'NonEmpty' list
 nonempty
-  :: Encoder a
-  -> Encoder (NonEmpty a)
+  :: Applicative f
+  => Encoder f a
+  -> Encoder f (NonEmpty a)
 nonempty =
   traversable
 
+-- | Encode a standard Haskell list
 list
-  :: Encoder a
-  -> Encoder [a]
+  :: Applicative f
+  => Encoder f a
+  -> Encoder f [a]
 list =
+  traversable
+
+json' :: Encoder' Json
+json' = json
+
+int' :: Encoder' Int
+int' = int
+
+bool' :: Encoder' Bool
+bool' = bool
+
+text' :: Encoder' Text
+text' = text
+
+null' :: Encoder' ()
+null' = null
+
+maybe'
+  :: Encoder' ()
+  -> Encoder' a
+  -> Encoder' (Maybe a)
+maybe' =
+  maybe
+
+maybeOrNull'
+  :: Encoder' a
+  -> Encoder' (Maybe a)
+maybeOrNull' =
+  maybeOrNull
+
+either'
+  :: Encoder' a
+  -> Encoder' b
+  -> Encoder' (Either a b)
+either' =
+  either
+
+nonempty'
+  :: Encoder' a
+  -> Encoder' (NonEmpty a)
+nonempty' =
+  traversable
+
+list'
+  :: Encoder' a
+  -> Encoder' [a]
+list' =
   traversable
 
 -- | Encode some 'a' that is contained with another 't' structure.
@@ -273,62 +288,52 @@ encodeWithInner
      , Traversable t
      )
   => (t Json -> Json)
-  -> Encoder' f a
-  -> Encoder' f (t a)
+  -> Encoder f a
+  -> Encoder f (t a)
 encodeWithInner f g =
-  Encoder' $ fmap f . traverse (runEncoder g)
+  Encoder $ fmap f . traverse (runEncoder g)
 
--- | Encode some 'Traversable' of 'a' into a JSON array.
 traversable'
-  :: ( Applicative f
-     , Traversable t
-     )
-  => Encoder' f a
-  -> Encoder' f (t a)
-traversable' = encodeWithInner
-  (\xs -> _JArr # (_Wrapped # foldr cons mempty xs, mempty))
-
-traversable
   :: Traversable t
-  => Encoder a
-  -> Encoder (t a)
-traversable = Encoder
-  . traversable'
-  . unEncoder
-
--- | Encode a 'Map' in a JSON object.
-mapToObj'
-  :: Applicative f
-  => Encoder' f a
-  -> (k -> Text)
-  -> Encoder' f (Map k a)
-mapToObj' encodeVal kToText =
-  let
-    mapToCS = Map.foldrWithKey (\k v -> at (kToText k) ?~ v) (_Empty # ())
-  in
-    encodeWithInner (\xs -> _JObj # (fromMapLikeObj $ mapToCS xs, mempty)) encodeVal
+  => Encoder' a
+  -> Encoder' (t a)
+traversable' =
+  traversable
 
 -- | Using the given function to convert the 'k' type keys to a 'Text' value,
 -- encode a 'Map' as a JSON object.
-mapToObj
-  :: Encoder a
+mapToObj'
+  :: Encoder' a
   -> (k -> Text)
-  -> Encoder (Map k a)
-mapToObj e = Encoder
-  . mapToObj' (unEncoder e)
+  -> Encoder' (Map k a)
+mapToObj' =
+  mapToObj
+
+atKey
+  :: ( At t
+     , IxValue t ~ Json
+     , Applicative f
+     )
+  => Index t
+  -> Encoder f a
+  -> a
+  -> t
+  -> f t
+atKey k enc v t =
+  (\v' -> t & at k ?~ v') <$> runEncoder enc v
 
 -- | Encode an 'a' at the given index on the JSON object.
-atKey
+atKey'
   :: ( At t
      , IxValue t ~ Json
      )
   => Index t
-  -> Encoder a
+  -> Encoder' a
   -> a
   -> t
   -> t
-atKey k enc v =
-  at k ?~ runIdentity (runEncoder (unEncoder enc) v)
+atKey' k enc v =
+  at k ?~ runIdentity (runEncoder enc v)
 
 -- | Encode an 'Int' at the given 'Text' key.
 intAt
@@ -337,7 +342,7 @@ intAt
   -> MapLikeObj WS Json
   -> MapLikeObj WS Json
 intAt =
-  flip atKey int
+  flip atKey' int
 
 -- | Encode a 'Text' value at the given 'Text' key.
 textAt
@@ -346,7 +351,7 @@ textAt
   -> MapLikeObj WS Json
   -> MapLikeObj WS Json
 textAt =
-  flip atKey text
+  flip atKey' text
 
 -- | Encode a 'Bool' at the given 'Text' key.
 boolAt
@@ -355,48 +360,47 @@ boolAt
   -> MapLikeObj WS Json
   -> MapLikeObj WS Json
 boolAt =
-  flip atKey bool
+  flip atKey' bool
 
 -- | Encode a 'Foldable' of 'a' at the given index on a JSON object.
-foldableAt
+traversableAt
   :: ( At t
      , Traversable f
-     , Foldable f
      , IxValue t ~ Json
      )
-  => Encoder a
+  => Encoder' a
   -> Index t
   -> f a
   -> t
   -> t
-foldableAt enc =
-  flip atKey (traversable enc)
+traversableAt enc =
+  flip atKey' (traversable enc)
 
 -- | Encode a standard Haskell list at the given index on a JSON object.
 listAt
   :: ( At t
      , IxValue t ~ Json
      )
-  => Encoder a
+  => Encoder' a
   -> Index t
   -> [a]
   -> t
   -> t
 listAt =
-  foldableAt
+  traversableAt
 
 -- | Encode a 'NonEmpty' list at the given index on a JSON object.
 nonemptyAt
   :: ( At t
      , IxValue t ~ Json
      )
-  => Encoder a
+  => Encoder' a
   -> Index t
   -> NonEmpty a
   -> t
   -> t
 nonemptyAt =
-  foldableAt
+  traversableAt
 
 -- | Apply a function to update a 'MapLikeObj' and encode that as a JSON object.
 --
@@ -416,7 +420,7 @@ nonemptyAt =
 -- update functions to set the keys and values as desired.
 --
 -- @
--- encodeImage :: Applicative f => Encoder' f Image
+-- encodeImage :: Applicative f => Encoder f Image
 -- encodeImage = encodeAsMapLikeObj $ \\img ->
 --   intAt \"Width\" (_imageW img) .           -- ^ Set an 'Int' value at the \"Width\" key.
 --   intAt \"Height\" (_imageH img) .
@@ -429,8 +433,69 @@ mapLikeObj
   :: ( AsJType Json ws a
      , Semigroup ws
      , Monoid ws
+     , Applicative f
      )
   => (i -> MapLikeObj ws a -> MapLikeObj ws a)
-  -> Encoder i
-mapLikeObj f = encodePureA $ \a ->
+  -> Encoder f i
+mapLikeObj f = encodeA $ \a ->
+  pure $ _JObj # (fromMapLikeObj $ f a (_Empty # ()), mempty)
+
+-- | As per 'mapLikeObj' but specialised for 'Identity' as the 'Applicative'.
+mapLikeObj'
+  :: ( AsJType Json ws a
+     , Semigroup ws
+     , Monoid ws
+     )
+  => (i -> MapLikeObj ws a -> MapLikeObj ws a)
+  -> Encoder' i
+mapLikeObj' f = encodePureA $ \a ->
   _JObj # (fromMapLikeObj $ f a (_Empty # ()), mempty)
+
+onObj
+  :: Applicative f
+  => Text
+  -> b
+  -> Encoder f b
+  -> JObject WS Json
+  -> f (JObject WS Json)
+onObj k b encB o = (\j -> o & _Wrapped L.%~ L.cons j)
+  . JAssoc (textToJString k) mempty mempty <$> runEncoder encB b
+
+-- | Encode key value pairs as a JSON object, allowing duplicate keys.
+keyValuesAsObj
+  :: ( Foldable g
+     , Semigroup ws
+     , Monoid ws
+     , AsJType Json ws j
+     , Monad f
+     )
+  => g (a -> JObject WS Json -> f (JObject WS Json))
+  -> Encoder f a
+keyValuesAsObj xs = encodeA $ \a ->
+  (\v -> _JObj # (v,mempty)) <$> foldrM (\f -> f a) (_Empty # ()) xs
+
+-- | As per 'keyValuesAsObj' but with the 'f' specialised to 'Identity'.
+keyValuesAsObj'
+  :: ( Foldable g
+     , Functor g
+     , Semigroup ws
+     , Monoid ws
+     , AsJType Json ws j
+     )
+  => g (a -> JObject WS Json -> JObject WS Json)
+  -> Encoder' a
+keyValuesAsObj' =
+  keyValuesAsObj . fmap (\f a -> Identity . f a)
+
+-- | Using a given 'Encoder', encode a key value pair on the JSON object, using
+-- the accessor function to retrieve the value.
+encAt
+  :: Applicative f
+  => Encoder f b
+  -> Text
+  -> (a -> b)
+  -> a
+  -> JObject WS Json
+  -> f (JObject WS Json)
+encAt e k f a =
+  onObj k (f a) e

--- a/src/Waargonaut/Types/CommaSep.hs
+++ b/src/Waargonaut/Types/CommaSep.hs
@@ -46,12 +46,13 @@ import           Control.Applicative     (Applicative (..), liftA2, pure, (*>),
                                           (<*), (<*>))
 import           Control.Category        (id, (.))
 
-import           Control.Lens            (AsEmpty (..), Cons (..), Index, Iso, Snoc (..),
-                                          Iso', IxValue, Ixed (..), Lens', cons, _Just,
-                                          from, isn't, iso, mapped, nearly,
-                                          over, prism, snoc, to, traverse,
-                                          unsnoc, (%%~), (%~), (.~), (^.),
-                                          (^..), (^?), _1, _2, _Cons, _Nothing)
+import           Control.Lens            (AsEmpty (..), Cons (..), Index, Iso,
+                                          Iso', IxValue, Ixed (..), Lens',
+                                          Snoc (..), cons, from, isn't, iso,
+                                          mapped, nearly, over, prism, snoc, to,
+                                          traverse, unsnoc, (%%~), (%~), (.~),
+                                          (^.), (^..), (^?), _1, _2, _Cons,
+                                          _Just, _Nothing)
 
 import           Control.Error.Util      (note)
 import           Control.Monad           (Monad)
@@ -60,14 +61,14 @@ import           Data.Bifoldable         (Bifoldable (bifoldMap))
 import           Data.Bifunctor          (Bifunctor (bimap))
 import           Data.Bitraversable      (Bitraversable (bitraverse))
 import           Data.Char               (Char)
+import           Data.Either             (Either (..))
 import           Data.Foldable           (Foldable, asum, foldMap, foldr,
                                           length)
-import           Data.Function           (const, ($), (&), flip)
+import           Data.Function           (const, flip, ($), (&))
 import           Data.Functor            (Functor, fmap, (<$), (<$>))
 import           Data.Functor.Classes    (Eq1, Show1, eq1, showsPrec1)
 import           Data.Maybe              (Maybe (..), fromMaybe, maybe)
 import           Data.Monoid             (Monoid (..), mempty)
-import Data.Either (Either (..))
 import           Data.Semigroup          (Semigroup ((<>)))
 import           Data.Traversable        (Traversable)
 import           Data.Tuple              (snd, uncurry)

--- a/test/Types/Common.hs
+++ b/test/Types/Common.hs
@@ -17,9 +17,11 @@ module Types.Common
   , parseBS
 
   , testImageDataType
+  , testFudge
 
   -- * Some test types to be messed with
   , Image (..)
+  , Fudge (..)
   , HasImage (..)
   ) where
 
@@ -51,7 +53,7 @@ import qualified Waargonaut.Encode           as E
 import           Waargonaut.Types            (Json)
 import           Waargonaut.Types.Whitespace (Whitespace (..))
 
-import           Waargonaut.Generic          (JsonDecode (..), JsonEncode (..),
+import           Waargonaut.Generic          (JsonDecode (..), JsonEncode (..), NewtypeName (..),
                                               Options (..), defaultOpts,
                                               gDecoder, gEncoder)
 
@@ -73,15 +75,34 @@ instance HasDatatypeInfo Image
 
 imageOpts :: Options
 imageOpts = defaultOpts
-  { _optionsFieldName = \s -> fromMaybe s $ List.stripPrefix "_image" s
+  { _optionsFieldName = \s ->
+      fromMaybe s $ List.stripPrefix "_image" s
   }
 
--- | You can just 'generics-sop' to automatically create an Encoder for you,
--- however it is not a very clever system and may not behave precisely as you
--- require. Be sure to check your outputs!
+-- | You can just 'generics-sop' to automatically create an Encoder for you. Be
+-- sure to check your outputs as the Generic system must make some assumptions
+-- about how certain things are structured. These assumptions may not agree with
+-- your expectations so always check.
 instance JsonEncode Image where mkEncoder = gEncoder imageOpts
 instance JsonDecode Image where mkDecoder = gDecoder imageOpts
 
+newtype Fudge = Fudge Text
+  deriving (Eq, Show, GHC.Generic)
+
+instance Generic Fudge
+instance HasDatatypeInfo Fudge
+
+fudgeJsonOpts :: Options
+fudgeJsonOpts = defaultOpts
+  { _optionsNewtypeWithConsName = ConstructorNameAsKey
+  , _optionsFieldName           = const "fudgey"
+  }
+
+instance JsonEncode Fudge where mkEncoder = gEncoder fudgeJsonOpts
+instance JsonDecode Fudge where mkDecoder = gDecoder fudgeJsonOpts
+
+testFudge :: Fudge
+testFudge = Fudge "Chocolate"
 genDecimalDigit :: Gen DecDigit
 genDecimalDigit = Gen.element decimalDigit
 


### PR DESCRIPTION
The Encoder types were a bit of a mess and were sort of the opposite of the
Decoder type, in name only. So this is largely a cosmetic change with names
changed to protect the applicative...

Some encoder functions have been removed/cleaned up. New encoder functions have
been added to allow for JSON objects with duplicate keys.

Fixed up a bug in the generic newtype encoder/decoder.

Updated the generics to handle the shift in the encoders.

Added some more tests.