### PR TITLE
Loosen the bytestring lower bound to support GHC 7.10 boot libraries

### DIFF
--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -103,7 +103,7 @@ library
                      , lens                >= 4.15   && < 5
                      , mtl                 >= 2.2.2  && < 3
                      , text                >= 1.2    && < 1.3
-                     , bytestring          >= 0.10.8 && < 0.11
+                     , bytestring          >= 0.10.6 && < 0.11
                      , parsers             >= 0.12   && < 0.13
                      , digit               >= 0.7    && < 0.8
                      , semigroups          >= 0.8.4  && < 0.19
@@ -179,7 +179,7 @@ test-suite waarg-tests
                      , tasty-hedgehog         >= 0.2    && < 0.3
                      , lens                   >= 4.15   && < 5
                      , distributive           >= 0.5    && < 0.7
-                     , bytestring             >= 0.10.8 && < 0.11
+                     , bytestring             >= 0.10.6 && < 0.11
                      , digit                  >= 0.7    && < 0.8
                      , text                   >= 1.2    && < 1.3
                      , semigroups             >= 0.8.4  && < 0.19


### PR DESCRIPTION
(waiting on https://github.com/haskell-works/hw-json/pull/28)