### PR TITLE
Tagged Generic Encoder/Decoder

### DIFF
--- a/src/Waargonaut/Encode.hs
+++ b/src/Waargonaut/Encode.hs
@@ -2,10 +2,10 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE RankNTypes            #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TupleSections         #-}
 {-# LANGUAGE TypeFamilies          #-}
-{-# LANGUAGE RankNTypes #-}
 -- | Types and functions to encode your data types to 'Json'.
 module Waargonaut.Encode
   (
@@ -77,9 +77,10 @@ import           Control.Monad.Morph        (MFunctor (..), generalize)
 
 import           Control.Applicative        (Applicative (..), (<$>))
 import           Control.Category           (id, (.))
-import           Control.Lens               (AReview, At, Index, IxValue, Prism',
-                                             Rewrapped, Wrapped (..), at, cons,
-                                             iso, ( # ), (?~), _Empty, _Wrapped)
+import           Control.Lens               (AReview, At, Index, IxValue,
+                                             Prism', Rewrapped, Wrapped (..),
+                                             at, cons, iso, ( # ), (?~), _Empty,
+                                             _Wrapped)
 import qualified Control.Lens               as L
 
 import           Prelude                    (Bool, Int, Monad)
@@ -109,11 +110,11 @@ import qualified Data.Map                   as Map
 
 import           Data.Text                  (Text)
 
-import           Waargonaut.Types.Json (waargonautBuilder)
 import           Waargonaut.Types           (AsJType (..), JAssoc (..), JObject,
                                              Json, MapLikeObj (..), WS,
                                              textToJString, wsRemover,
                                              _JNumberInt, _JNumberScientific)
+import           Waargonaut.Types.Json      (waargonautBuilder)
 
 -- |
 -- Define an "encoder" as a function from some @a@ to some 'Json' with the

--- a/src/Waargonaut/Encode.hs
+++ b/src/Waargonaut/Encode.hs
@@ -109,7 +109,7 @@ import qualified Data.Map                   as Map
 
 import           Data.Text                  (Text)
 
-import           Waargonaut                 (waargonautBuilder)
+import           Waargonaut.Types.Json (waargonautBuilder)
 import           Waargonaut.Types           (AsJType (..), JAssoc (..), JObject,
                                              Json, MapLikeObj (..), WS,
                                              textToJString, wsRemover,

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -345,7 +345,7 @@ gDecoderConstructor
   -> NP JsonInfo xss
   -> DecodeResultT Count DecodeError f (SOP I xss)
 gDecoderConstructor opts pJAll parseFn cursor ninfo =
-  foldForRight . hcollapse $ hcliftA2 pJAll (mkGDecoder opts pJDec parseFn cursor) ninfo injs
+  foldForRight . hcollapse $ hcliftA2 pJAll (mkGDecoder opts pJDec cursor) ninfo injs
   where
     pJDec = Proxy :: Proxy (JsonDecode t)
 
@@ -372,12 +372,11 @@ mkGDecoder
      )
   => Options
   -> Proxy (JsonDecode t)
-  -> D.ParseFn
   -> D.JCurs
   -> JsonInfo xs
   -> Injection (NP I) xss xs
   -> K (D.DecodeResult f (SOP I xss)) xs
-mkGDecoder opts pJDec _parseFn cursor info (Fn inj) = K $ do
+mkGDecoder opts pJDec cursor info (Fn inj) = K $ do
   val <- mkGDecoder2 opts pJDec cursor info
   SOP . unK . inj <$> hsequence (hcliftA pJDec (aux pJDec) val)
   where

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -39,13 +39,14 @@ module Waargonaut.Generic
     -- * Helpers
   , wGJEnc1
   , wGJEnc2
+  , wGJDec1
+  , wGJDec2
 
   ) where
 
 import           Generics.SOP
 
-import           Control.Lens                  (Rewrapped, Wrapped (..), findOf,
-                                                folded, isn't, iso, _Left)
+import           Control.Lens                  (findOf, folded, isn't, _Left)
 import           Control.Monad                 ((>=>))
 import           Control.Monad.Except          (lift, throwError)
 import           Control.Monad.State           (modify)
@@ -99,12 +100,6 @@ newtype GJsonEncoder t f a = GJEnc
   { unGJEnc :: Encoder f a
   }
 
-instance GJsonEncoder t f a ~ Encoder f a => Rewrapped (GJsonEncoder t f a) (Encoder f a)
-
-instance Wrapped (GJsonEncoder t f a) where
-  type Unwrapped (GJsonEncoder t f a) = Encoder f a
-  _Wrapped' = iso unGJEnc GJEnc
-
 instance Contravariant (GJsonEncoder t f) where
   contramap f (GJEnc e) = GJEnc (contramap f e)
 
@@ -146,14 +141,9 @@ instance JsonEncode t Bool                                             where mkE
 newtype GJsonDecoder t f a = GJDec
   { unGJDec :: Decoder f a
   }
-  deriving ( Functor
-           , Applicative
-           , Monad
-           )
 
 generaliseGJDecoder :: Monad f => GJsonDecoder t Identity a -> GJsonDecoder t f a
 generaliseGJDecoder = GJDec . D.generaliseDecoder . unGJDec
-
 
 wGJDec1
   :: (Decoder f a -> Decoder f (g a))
@@ -167,7 +157,6 @@ wGJDec2
   -> GJsonDecoder t f a
   -> GJsonDecoder t f b
   -> GJsonDecoder t f (g a b)
-
 wGJDec2 e (GJDec ga) (GJDec gb) =
   GJDec (e ga gb)
 

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -18,7 +18,7 @@ import qualified Data.ByteString            as BS
 import qualified Data.Either                as Either
 import           Data.Function              (($))
 
-import           Waargonaut.Generic         (mkDecoder)
+import           Waargonaut.Generic         (mkDecoder, unGJDec)
 
 import           Waargonaut.Decode.Internal (ppCursorHistory)
 
@@ -48,8 +48,8 @@ decodeTest2Json :: Assertion
 decodeTest2Json = assertBool "[Int] Decode Success" . Either.isRight
   $ D.runPureDecode listDecode parseBS (D.mkCursor "[23,44]")
   where
-    listDecode :: Monad f => D.Decoder f  [Int]
-    listDecode = mkDecoder
+    listDecode :: Monad f => D.Decoder f [Int]
+    listDecode = unGJDec mkDecoder
 
 decodeTest3Json :: Assertion
 decodeTest3Json = assertBool "(Char,String,[Int]) Decode Success" . Either.isRight

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -17,8 +17,9 @@ import           Test.Tasty.HUnit           (Assertion, assertBool, assertEqual,
 import qualified Data.ByteString            as BS
 import qualified Data.Either                as Either
 import           Data.Function              (($))
+import           Data.Tagged                (untag)
 
-import           Waargonaut.Generic         (mkDecoder, unGJDec)
+import           Waargonaut.Generic         (mkDecoder)
 
 import           Waargonaut.Decode.Internal (ppCursorHistory)
 
@@ -49,7 +50,7 @@ decodeTest2Json = assertBool "[Int] Decode Success" . Either.isRight
   $ D.runPureDecode listDecode parseBS (D.mkCursor "[23,44]")
   where
     listDecode :: Monad f => D.Decoder f [Int]
-    listDecode = unGJDec mkDecoder
+    listDecode = untag mkDecoder
 
 decodeTest3Json :: Assertion
 decodeTest3Json = assertBool "(Char,String,[Int]) Decode Success" . Either.isRight

--- a/test/Encoder.hs
+++ b/test/Encoder.hs
@@ -6,19 +6,18 @@ module Encoder
   , testImageDataType
   ) where
 
-import           Test.Tasty            (TestName, TestTree, testGroup)
-import           Test.Tasty.HUnit      (assertEqual, testCase)
+import           Test.Tasty           (TestName, TestTree, testGroup)
+import           Test.Tasty.HUnit     (assertEqual, testCase)
 
-import           Waargonaut.Encode     (Encoder, Encoder')
-import qualified Waargonaut.Encode     as E
+import           Waargonaut.Encode    (Encoder, Encoder')
+import qualified Waargonaut.Encode    as E
 
-import           Data.ByteString.Lazy  (ByteString)
-import           Data.Functor.Identity (Identity)
+import           Data.ByteString.Lazy (ByteString)
 
-import           Types.Common          (Fudge, Image (..), testFudge,
-                                        testImageDataType)
+import           Types.Common         (Fudge, Image (..), testFudge,
+                                       testImageDataType)
 
-import           Waargonaut.Generic    (GWaarg, GJsonEncoder (..), mkEncoder)
+import           Waargonaut.Generic   (GJsonEncoder (..), GWaarg, mkEncoder)
 
 testImageEncodedNoSpaces :: ByteString
 testImageEncodedNoSpaces = "{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Animated\":false,\"IDs\":[116,943,234,38793]}"

--- a/test/Encoder.hs
+++ b/test/Encoder.hs
@@ -17,7 +17,8 @@ import           Data.ByteString.Lazy (ByteString)
 import           Types.Common         (Fudge, Image (..), testFudge,
                                        testImageDataType)
 
-import           Waargonaut.Generic   (GJsonEncoder (..), GWaarg, mkEncoder)
+import           Data.Tagged          (Tagged, untag)
+import           Waargonaut.Generic   (GWaarg, mkEncoder)
 
 testImageEncodedNoSpaces :: ByteString
 testImageEncodedNoSpaces = "{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Animated\":false,\"IDs\":[116,943,234,38793]}"
@@ -49,13 +50,13 @@ tCase nm enc a =
 encoderTests :: TestTree
 encoderTests = testGroup "Encoder"
   [ tCase "Encode Image" encodeImage testImageDataType testImageEncodedNoSpaces
-  , tCase "Encode Image (Generic)" (unGJEnc imgE) testImageDataType testImageGenericEncode
-  , tCase "Encode newtype - with constructor name" (unGJEnc fudgeE) testFudge testFudgeEncodedWithConsName
+  , tCase "Encode Image (Generic)" (untag imgE) testImageDataType testImageGenericEncode
+  , tCase "Encode newtype - with constructor name" (untag fudgeE) testFudge testFudgeEncodedWithConsName
   ]
   where
-    imgE :: Applicative f => GJsonEncoder GWaarg f Image
+    imgE :: Applicative f => Tagged GWaarg (Encoder f Image)
     imgE = mkEncoder
 
-    fudgeE :: Applicative f => GJsonEncoder GWaarg f Fudge
+    fudgeE :: Applicative f => Tagged GWaarg (Encoder f Fudge)
     fudgeE = mkEncoder
 

--- a/test/Encoder.hs
+++ b/test/Encoder.hs
@@ -6,17 +6,19 @@ module Encoder
   , testImageDataType
   ) where
 
-import           Test.Tasty           (TestName, TestTree, testGroup)
-import           Test.Tasty.HUnit     (assertEqual, testCase)
+import           Test.Tasty            (TestName, TestTree, testGroup)
+import           Test.Tasty.HUnit      (assertEqual, testCase)
 
-import           Waargonaut.Encode    (Encoder, Encoder')
-import qualified Waargonaut.Encode    as E
+import           Waargonaut.Encode     (Encoder, Encoder')
+import qualified Waargonaut.Encode     as E
 
-import           Data.ByteString.Lazy (ByteString)
+import           Data.ByteString.Lazy  (ByteString)
+import           Data.Functor.Identity (Identity)
 
-import           Types.Common         (Image (..), testFudge, testImageDataType)
+import           Types.Common          (Fudge, Image (..), testFudge,
+                                        testImageDataType)
 
-import           Waargonaut.Generic   (mkEncoder)
+import           Waargonaut.Generic    (GWaarg, GJsonEncoder (..), mkEncoder)
 
 testImageEncodedNoSpaces :: ByteString
 testImageEncodedNoSpaces = "{\"Width\":800,\"Height\":600,\"Title\":\"View from 15th Floor\",\"Animated\":false,\"IDs\":[116,943,234,38793]}"
@@ -48,7 +50,13 @@ tCase nm enc a =
 encoderTests :: TestTree
 encoderTests = testGroup "Encoder"
   [ tCase "Encode Image" encodeImage testImageDataType testImageEncodedNoSpaces
-  , tCase "Encode Image (Generic)" mkEncoder testImageDataType testImageGenericEncode
-  , tCase "Encode newtype - with constructor name" mkEncoder testFudge testFudgeEncodedWithConsName
+  , tCase "Encode Image (Generic)" (unGJEnc imgE) testImageDataType testImageGenericEncode
+  , tCase "Encode newtype - with constructor name" (unGJEnc fudgeE) testFudge testFudgeEncodedWithConsName
   ]
+  where
+    imgE :: Applicative f => GJsonEncoder GWaarg f Image
+    imgE = mkEncoder
+
+    fudgeE :: Applicative f => GJsonEncoder GWaarg f Fudge
+    fudgeE = mkEncoder
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -42,7 +42,7 @@ import qualified Waargonaut.Decode           as D
 import           Waargonaut.Decode.Error     (DecodeError)
 import qualified Waargonaut.Encode           as E
 
-import Waargonaut.Generic (mkEncoder,mkDecoder)
+import           Waargonaut.Generic          (mkDecoder, mkEncoder)
 
 import qualified Types.CommaSep              as CS
 import qualified Types.Common                as Common

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -42,6 +42,8 @@ import qualified Waargonaut.Decode           as D
 import           Waargonaut.Decode.Error     (DecodeError)
 import qualified Waargonaut.Encode           as E
 
+import Waargonaut.Generic (mkEncoder)
+
 import qualified Types.CommaSep              as CS
 import qualified Types.Common                as Common
 import qualified Types.Json                  as J
@@ -123,20 +125,20 @@ prop_tripping_int_list = property $ do
 
 prop_tripping_image_record_generic :: Property
 prop_tripping_image_record_generic = withTests 1 . property $
-  Common.prop_generic_tripping Common.testImageDataType
+  Common.prop_generic_tripping mkEncoder Common.testImageDataType
 
 prop_tripping_newtype_fudge_generic :: Property
 prop_tripping_newtype_fudge_generic = withTests 1 . property $
-  Common.prop_generic_tripping Common.testFudge
+  Common.prop_generic_tripping mkEncoder Common.testFudge
 
 prop_tripping_maybe_bool_generic :: Property
 prop_tripping_maybe_bool_generic = property $
-  forAll (Gen.maybe Gen.bool) >>= Common.prop_generic_tripping
+  forAll (Gen.maybe Gen.bool) >>= Common.prop_generic_tripping mkEncoder
 
 prop_tripping_int_list_generic :: Property
 prop_tripping_int_list_generic = property $ do
   xs <- forAll . Gen.list (Range.linear 0 100) $ Gen.int (Range.linear 0 9999)
-  Common.prop_generic_tripping xs
+  Common.prop_generic_tripping mkEncoder xs
 
 prop_tripping :: Property
 prop_tripping = withTests 200 . property $

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -42,7 +42,7 @@ import qualified Waargonaut.Decode           as D
 import           Waargonaut.Decode.Error     (DecodeError)
 import qualified Waargonaut.Encode           as E
 
-import Waargonaut.Generic (mkEncoder)
+import Waargonaut.Generic (mkEncoder,mkDecoder)
 
 import qualified Types.CommaSep              as CS
 import qualified Types.Common                as Common
@@ -125,20 +125,20 @@ prop_tripping_int_list = property $ do
 
 prop_tripping_image_record_generic :: Property
 prop_tripping_image_record_generic = withTests 1 . property $
-  Common.prop_generic_tripping mkEncoder Common.testImageDataType
+  Common.prop_generic_tripping mkEncoder mkDecoder Common.testImageDataType
 
 prop_tripping_newtype_fudge_generic :: Property
 prop_tripping_newtype_fudge_generic = withTests 1 . property $
-  Common.prop_generic_tripping mkEncoder Common.testFudge
+  Common.prop_generic_tripping mkEncoder mkDecoder Common.testFudge
 
 prop_tripping_maybe_bool_generic :: Property
 prop_tripping_maybe_bool_generic = property $
-  forAll (Gen.maybe Gen.bool) >>= Common.prop_generic_tripping mkEncoder
+  forAll (Gen.maybe Gen.bool) >>= Common.prop_generic_tripping mkEncoder mkDecoder
 
 prop_tripping_int_list_generic :: Property
 prop_tripping_int_list_generic = property $ do
   xs <- forAll . Gen.list (Range.linear 0 100) $ Gen.int (Range.linear 0 9999)
-  Common.prop_generic_tripping mkEncoder xs
+  Common.prop_generic_tripping mkEncoder mkDecoder xs
 
 prop_tripping :: Property
 prop_tripping = withTests 200 . property $

--- a/test/Types/Common.hs
+++ b/test/Types/Common.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE OverloadedStrings     #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE TypeApplications #-}
 module Types.Common
   ( genDecimalDigit
   , genDecimalDigits
@@ -125,6 +124,9 @@ imageDecodeGeneric = SD.withCursor $ SD.fromKey "Image" iDec
 
   -- As above but with the niceness of TypeApplications (GHC > 8), even better
   -- where iDec = T.proxy mkDecoder (Proxy @GWaarg)
+
+  -- Even better with using TypeApplications directly on the 'mkDecoder'
+  -- where iDec = T.untag $ mkDecoder @GWaarg
 
 instance Generic Image
 instance HasDatatypeInfo Image

--- a/waargonaut-deps.nix
+++ b/waargonaut-deps.nix
@@ -22,6 +22,8 @@ in
 
   generic-lens   = pkgs.haskell.lib.dontCheck super.generic-lens;
 
+  tagged         = self.callHackage "tagged" "0.8.6" {};
+
   hw-parser      = self.callHackage "hw-parser" "0.1.0.0" {};
   hw-json        = self.callCabal2nix "hw-json" sources.hw-json {};
 })

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -100,34 +100,35 @@ library
   ghc-options:         -Wall
 
   -- Other library packages from which modules are imported.
-  build-depends:       base                >= 4.7    && < 4.13
-                     , lens                >= 4.15   && < 5
-                     , mtl                 >= 2.2.2  && < 3
-                     , text                >= 1.2    && < 1.3
-                     , bytestring          >= 0.10.6 && < 0.11
-                     , parsers             >= 0.12   && < 0.13
-                     , digit               >= 0.7    && < 0.8
-                     , semigroups          >= 0.8.4  && < 0.19
-                     , scientific          >= 0.3    && < 0.4
-                     , distributive        >= 0.5    && < 0.7
-                     , nats                >= 1      && <1.2
-                     , zippers             >= 0.2    && < 0.3
-                     , vector              >= 0.12   && < 0.13
-                     , errors              >= 2.2    && < 3
-                     , hoist-error         >= 0.2    && < 0.3
-                     , containers          >= 0.5.6  && < 0.7
-                     , witherable          >= 0.2    && < 0.3
-                     , generics-sop        >= 0.3.2  && < 4
-                     , mmorph              >= 1.1    && < 2
-                     , transformers        >= 0.4    && < 0.6
-                     , bifunctors          >= 5      && < 6
-                     , contravariant       >= 1.4    && < 2
-                     , wl-pprint-annotated >= 0.1    && < 0.2
-                     , hw-json             >= 0.9.0.1    && < 0.10
-                     , hw-prim             >= 0.6    && < 0.7
-                     , hw-balancedparens   >= 0.2    && < 0.3
-                     , hw-rankselect       >= 0.10   && < 0.13
-                     , hw-bits             >= 0.7    && < 0.8
+  build-depends:       base                >= 4.7     && < 4.13
+                     , lens                >= 4.15    && < 5
+                     , mtl                 >= 2.2.2   && < 3
+                     , text                >= 1.2     && < 1.3
+                     , bytestring          >= 0.10.6  && < 0.11
+                     , parsers             >= 0.12    && < 0.13
+                     , digit               >= 0.7     && < 0.8
+                     , semigroups          >= 0.8.4   && < 0.19
+                     , scientific          >= 0.3     && < 0.4
+                     , distributive        >= 0.5     && < 0.7
+                     , nats                >= 1       && <1.2
+                     , zippers             >= 0.2     && < 0.3
+                     , vector              >= 0.12    && < 0.13
+                     , errors              >= 2.2     && < 3
+                     , hoist-error         >= 0.2     && < 0.3
+                     , containers          >= 0.5.6   && < 0.7
+                     , witherable          >= 0.2     && < 0.3
+                     , generics-sop        >= 0.3.2   && < 4
+                     , mmorph              >= 1.1     && < 2
+                     , transformers        >= 0.4     && < 0.6
+                     , bifunctors          >= 5       && < 6
+                     , contravariant       >= 1.4     && < 2
+                     , wl-pprint-annotated >= 0.1     && < 0.2
+                     , hw-json             >= 0.9.0.1 && < 0.10
+                     , hw-prim             >= 0.6     && < 0.7
+                     , hw-balancedparens   >= 0.2     && < 0.3
+                     , hw-rankselect       >= 0.10    && < 0.13
+                     , hw-bits             >= 0.7     && < 0.8
+                     , tagged              >= 0.8.6   && < 0.9
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -142,14 +143,14 @@ test-suite doctests
   hs-source-dirs:      test
 
   build-depends:       base             >= 4.7  && < 4.13
-                     , doctest          >= 0.9.7
-                     , filepath         >= 1.3
-                     , directory        >= 1.1
-                     , template-haskell >= 2.8
                      , hedgehog         >= 0.6  && < 0.7
                      , text             >= 1.2  && < 1.3
                      , digit            >= 0.7  && < 0.8
                      , attoparsec       >= 0.13 && < 0.15
+                     , doctest          >= 0.9.7
+                     , filepath         >= 1.3
+                     , directory        >= 1.1
+                     , template-haskell >= 2.8
 
                      , waargonaut
 
@@ -188,6 +189,8 @@ test-suite waarg-tests
                      , generics-sop           >= 0.3.2  && < 0.4
                      , attoparsec             >= 0.13   && < 0.15
                      , scientific             >= 0.3    && < 0.4
+                     , tagged                 >= 0.8.6  && < 0.9
+ 
 
                      , waargonaut
 

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -3,9 +3,9 @@
 , distributive, doctest, errors, filepath, generics-sop, hedgehog
 , hoist-error, hw-balancedparens, hw-bits, hw-json, hw-prim
 , hw-rankselect, lens, mmorph, mtl, nats, parsers, scientific
-, semigroups, stdenv, tasty, tasty-expected-failure, tasty-hedgehog
-, tasty-hunit, template-haskell, text, transformers, vector
-, witherable, wl-pprint-annotated, zippers
+, semigroups, stdenv, tagged, tasty, tasty-expected-failure
+, tasty-hedgehog, tasty-hunit, template-haskell, text, transformers
+, vector, witherable, wl-pprint-annotated, zippers
 }:
 mkDerivation {
   pname = "waargonaut";
@@ -16,7 +16,7 @@ mkDerivation {
     base bifunctors bytestring containers contravariant digit
     distributive errors generics-sop hoist-error hw-balancedparens
     hw-bits hw-json hw-prim hw-rankselect lens mmorph mtl nats parsers
-    scientific semigroups text transformers vector witherable
+    scientific semigroups tagged text transformers vector witherable
     wl-pprint-annotated zippers
   ];
   testHaskellDepends = [


### PR DESCRIPTION
The Generic functionality as it is in Waargonaut is too restrictive and has all of the same problems that the `aeson` typeclass technique has. It limits the utility of the generics and provides no additional safety, defeating the purpose of using Waargonaut.

This PR is to change the `JsonEncode` and `JsonDecode` typeclass functions to require an additional type parameter, and use this parameter to tag the function that is returned. Using the `tagged` package:

`JsonEncode t a` provides `Tagged t (Encoder f a)`
&
`JsonDecode t a` provides `Tagged t (Decoder f a)`

This allows the user to benefit from the `Generic` machinery but maintain more precise control over which instances will be used. As an example:

```haskell
{-# LANGUAGE DataKinds #-}
data EndPoints
  = InternalOnly
  | Customer

instance JsonDecode 'InternalOnly Foo where ...
instance JsonDecode 'Customer     Foo  where ...

type API = 
  "internal" :> GET [WaargJSON 'InternalOnly] Foo <|> 
  "external" :> GET [WaargJSON 'Customer] Foo
```
This is a first attempt at the API so there isn't any niceness built around it, `Tagged` has a `Wrapped` instance from lens that might be useful. Feedback appreciated!!