### PR TITLE
Improve errors from 'moveToKey'.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Revision history for waargonaut
 
+## 0.1.0.1  -- 2018-11-06
+
+* Provide more precise errors from Decoder for missing or invalid keys
+* Fix issue where printing the zipper movements had left and right movement arrows swapped.
+
 ## 0.1.0.0  -- 2018-11-01
 
 * First version. Released on an unsuspecting world.

--- a/src/Waargonaut/Decode/Error.hs
+++ b/src/Waargonaut/Decode/Error.hs
@@ -29,7 +29,7 @@ data Err c e
 --
 data DecodeError
   = ConversionFailure Text
-  | KeyDecodeFailed Text
+  | KeyDecodeFailed
   | KeyNotFound Text
   | FailedToMove ZipperMove
   | NumberOutOfBounds JNumber
@@ -41,7 +41,7 @@ data DecodeError
 class AsDecodeError r where
   _DecodeError       :: Prism' r DecodeError
   _ConversionFailure :: Prism' r Text
-  _KeyDecodeFailed   :: Prism' r Text
+  _KeyDecodeFailed   :: Prism' r ()
   _KeyNotFound       :: Prism' r Text
   _FailedToMove      :: Prism' r ZipperMove
   _NumberOutOfBounds :: Prism' r JNumber
@@ -67,10 +67,10 @@ instance AsDecodeError DecodeError where
         )
 
   _KeyDecodeFailed
-    = L.prism KeyDecodeFailed
+    = L.prism (const KeyDecodeFailed)
         (\x -> case x of
-            KeyDecodeFailed y -> Right y
-            _                 -> Left x
+            KeyDecodeFailed -> Right ()
+            _               -> Left x
         )
 
   _KeyNotFound

--- a/src/Waargonaut/Decode/ZipperMove.hs
+++ b/src/Waargonaut/Decode/ZipperMove.hs
@@ -34,10 +34,10 @@ data ZipperMove
 ppZipperMove :: ZipperMove -> Doc a
 ppZipperMove m = case m of
   U        -> WL.text "up/"
-  D        -> WL.text "into\\"
+  D        -> WL.text "down\\"
 
-  (L n)    -> WL.text "->-" <+> ntxt n
-  (R n)    -> WL.text "-<-" <+> ntxt n
+  (L n)    -> WL.text "-<-" <+> ntxt n
+  (R n)    -> WL.text "->-" <+> ntxt n
 
   (DAt k)  -> WL.text "into\\" <+> itxt "key" k
   (Item t) -> WL.text "-::" <+> itxt "item" t

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.1.0.0
+version:             0.1.0.1
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -9,7 +9,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.1.0.0";
+  version = "0.1.0.1";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [
@@ -21,9 +21,9 @@ mkDerivation {
   ];
   testHaskellDepends = [
     attoparsec base bytestring digit directory distributive doctest
-    filepath generics-sop hedgehog lens scientific semigroups tasty
-    tasty-expected-failure tasty-hedgehog tasty-hunit template-haskell
-    text vector zippers
+    filepath generics-sop hedgehog lens scientific semigroups tagged
+    tasty tasty-expected-failure tasty-hedgehog tasty-hunit
+    template-haskell text vector zippers
   ];
   homepage = "https://github.com/qfpl/waargonaut";
   description = "JSON wrangling";


### PR DESCRIPTION
Add more precise errors for either an invalid key decode attempt or when moving
off the end of the object looking for a key.

Removed param for KeyDecodeFailed error as there is no more information.

Bumped minor version and updated changelog.