### PR TITLE
Add movement recording for moveToKey function.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for waargonaut
 
+## 0.2.0.1  -- 2018-11-07
+
+* Update `moveToKey` to record a successful movement to a key, before continuing
+
 ## 0.2.0.0  -- 2018-11-06
 
 * Provide more precise errors from Decoder for missing or invalid keys

--- a/src/Waargonaut/Decode.hs
+++ b/src/Waargonaut/Decode.hs
@@ -430,7 +430,7 @@ moveToKey k c = do
   -- Are we at the key we want to be at ?
   if k' == k
     -- Then move into the THING at the key
-    then moveRight1 c
+    then recordRank (DAt k) c >> moveRight1 c
     -- Try jump to the next key index
     else ( DI.try (moveRightN 2 c) <!?> (_KeyNotFound # k) ) >>= moveToKey k
 

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.2.0.0
+version:             0.2.0.1
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -9,7 +9,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.2.0.0";
+  version = "0.2.0.1";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
The `moveToKey` function was not recording the movement from the key onto the
value if it was successfully found. This change just adds that recording step
and continues as normal.