### PR TITLE
Add MonadError instance for Decoder

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,14 @@
 # Revision history for waargonaut
 
+## 0.2.0.3  -- 2018-11-13
+
+* Add `MonadError` and `Alt` instance for `Decoder`
+* Add property tests for the typeclass laws for `Encoder` and `Decoder`
+
+## 0.2.0.2  -- 2018-11-12
+
+* Fix `Applicative` instance for `Decoder`.
+
 ## 0.2.0.1  -- 2018-11-07
 
 * Update `moveToKey` to record a successful movement to a key, before continuing

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Revision history for waargonaut
 
-## 0.2.0.3  -- 2018-11-13
+## 0.2.1.0  -- 2018-11-13
 
 * Add `MonadError` and `Alt` instance for `Decoder`
 * Add property tests for the typeclass laws for `Encoder` and `Decoder`

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,7 @@
 
 * Add `MonadError` and `Alt` instance for `Decoder`
 * Add property tests for the typeclass laws for `Encoder` and `Decoder`
+* Removed need for `MonadError` constraint on `prismDOrFail`
 
 ## 0.2.0.2  -- 2018-11-12
 

--- a/src/Waargonaut/Decode.hs
+++ b/src/Waargonaut/Decode.hs
@@ -86,8 +86,8 @@ import           Control.Lens                              (Cons, Lens', Prism',
                                                             Snoc, cons, lens,
                                                             modifying, preview,
                                                             snoc, traverseOf,
-                                                            view, (.~), (^.), (#),
-                                                            _Wrapped)
+                                                            view, ( # ), (.~),
+                                                            (^.), _Wrapped)
 
 import           Prelude                                   (Bool, Bounded, Char,
                                                             Int, Integral,
@@ -100,15 +100,14 @@ import           Control.Category                          ((.))
 import           Control.Monad                             (Monad (..), (>=>))
 import           Control.Monad.Morph                       (embed, generalize)
 
-import           Control.Monad.Except                      (MonadError, lift,
-                                                            liftEither,
+import           Control.Monad.Except                      (lift, liftEither,
                                                             throwError)
 import           Control.Monad.Reader                      (ReaderT (..), ask,
                                                             local, runReaderT)
 import           Control.Monad.State                       (MonadState)
 
 import           Control.Error.Util                        (note)
-import           Control.Monad.Error.Hoist                 ((<?>),(<!?>))
+import           Control.Monad.Error.Hoist                 ((<!?>), (<?>))
 
 import           Data.Either                               (Either (..))
 import           Data.Foldable                             (foldl)
@@ -148,7 +147,8 @@ import           HaskellWorks.Data.Json.Cursor             (JsonCursor (..))
 import qualified HaskellWorks.Data.Json.Cursor             as JC
 
 
-import           Waargonaut.Decode.Error                   (DecodeError (..), AsDecodeError (..),
+import           Waargonaut.Decode.Error                   (AsDecodeError (..),
+                                                            DecodeError (..),
                                                             Err (..))
 import           Waargonaut.Decode.ZipperMove              (ZipperMove (..))
 
@@ -653,13 +653,13 @@ prismD p =
 
 -- | As per 'prismD' but fail the 'Decoder' if unsuccessful.
 prismDOrFail
-  :: MonadError DecodeError f
+  :: Monad f
   => DecodeError
   -> Prism' a b
   -> Decoder f a
   -> Decoder f b
-prismDOrFail e p d = Decoder $ \pf ->
-  DI.prismDOrFail' e p (DI.Decoder' $ runDecoder d pf)
+prismDOrFail e p d = withCursor $
+  focus d >=> \a -> preview p a <?> e
 
 -- | Decode an 'Int'.
 int :: Monad f => Decoder f Int

--- a/src/Waargonaut/Decode/Error.hs
+++ b/src/Waargonaut/Decode/Error.hs
@@ -35,6 +35,7 @@ data DecodeError
   | NumberOutOfBounds JNumber
   | InputOutOfBounds Word64
   | ParseFailed Text
+  | EmptyDecodeFailure
   deriving (Show, Eq)
 
 -- | Describes the sorts of errors that may be treated as a 'DecodeError', for use with 'lens'.
@@ -47,6 +48,7 @@ class AsDecodeError r where
   _NumberOutOfBounds :: Prism' r JNumber
   _InputOutOfBounds  :: Prism' r Word64
   _ParseFailed       :: Prism' r Text
+  _EmptyDecodeFailure :: Prism' r ()
 
   _ConversionFailure = _DecodeError . _ConversionFailure
   _KeyDecodeFailed   = _DecodeError . _KeyDecodeFailed
@@ -55,6 +57,7 @@ class AsDecodeError r where
   _NumberOutOfBounds = _DecodeError . _NumberOutOfBounds
   _InputOutOfBounds  = _DecodeError . _InputOutOfBounds
   _ParseFailed       = _DecodeError . _ParseFailed
+  _EmptyDecodeFailure       = _DecodeError . _EmptyDecodeFailure
 
 instance AsDecodeError DecodeError where
   _DecodeError = id

--- a/src/Waargonaut/Decode/Error.hs
+++ b/src/Waargonaut/Decode/Error.hs
@@ -35,7 +35,6 @@ data DecodeError
   | NumberOutOfBounds JNumber
   | InputOutOfBounds Word64
   | ParseFailed Text
-  | EmptyDecodeFailure
   deriving (Show, Eq)
 
 -- | Describes the sorts of errors that may be treated as a 'DecodeError', for use with 'lens'.
@@ -48,7 +47,6 @@ class AsDecodeError r where
   _NumberOutOfBounds :: Prism' r JNumber
   _InputOutOfBounds  :: Prism' r Word64
   _ParseFailed       :: Prism' r Text
-  _EmptyDecodeFailure :: Prism' r ()
 
   _ConversionFailure = _DecodeError . _ConversionFailure
   _KeyDecodeFailed   = _DecodeError . _KeyDecodeFailed
@@ -57,7 +55,6 @@ class AsDecodeError r where
   _NumberOutOfBounds = _DecodeError . _NumberOutOfBounds
   _InputOutOfBounds  = _DecodeError . _InputOutOfBounds
   _ParseFailed       = _DecodeError . _ParseFailed
-  _EmptyDecodeFailure       = _DecodeError . _EmptyDecodeFailure
 
 instance AsDecodeError DecodeError where
   _DecodeError = id

--- a/src/Waargonaut/Decode/Internal.hs
+++ b/src/Waargonaut/Decode/Internal.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE FlexibleInstances          #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MultiParamTypeClasses      #-}
+{-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE TupleSections              #-}
 {-# LANGUAGE TypeFamilies               #-}
-{-# LANGUAGE RankNTypes #-}
 -- | Internal types and functions for building Decoder infrastructure.
 module Waargonaut.Decode.Internal
   ( CursorHistory' (..)
@@ -54,7 +54,7 @@ import           Control.Monad.Except          (ExceptT (..), MonadError (..),
 import           Control.Monad.State           (MonadState (..), StateT (..))
 import           Control.Monad.Trans.Class     (MonadTrans (lift))
 
-import           Control.Monad.Error.Hoist                 ((<!?>))
+import           Control.Monad.Error.Hoist     ((<!?>))
 import           Control.Monad.Morph           (MFunctor (..), MMonad (..))
 
 import           Data.Bifunctor                (first)

--- a/src/Waargonaut/Decode/ZipperMove.hs
+++ b/src/Waargonaut/Decode/ZipperMove.hs
@@ -34,14 +34,14 @@ data ZipperMove
 -- 'Waargonaut.Decode.Internal.CursorHistory'' to improve the readability of the errors.
 ppZipperMove :: ZipperMove -> Doc a
 ppZipperMove m = case m of
-  U        -> WL.text "up/"
-  D        -> WL.text "down\\"
+  U              -> WL.text "up/"
+  D              -> WL.text "down\\"
 
-  (L n)    -> WL.text "-<-" <+> ntxt n
-  (R n)    -> WL.text "->-" <+> ntxt n
+  (L n)          -> WL.text "-<-" <+> ntxt n
+  (R n)          -> WL.text "->-" <+> ntxt n
 
-  (DAt k)  -> WL.text "into\\" <+> itxt "key" k
-  (Item t) -> WL.text "-::" <+> itxt "item" t
+  (DAt k)        -> WL.text "into\\" <+> itxt "key" k
+  (Item t)       -> WL.text "-::" <+> itxt "item" t
   (BranchFail t) -> WL.text "(attempted: " <+> ntxt t <+> WL.text ")"
   where
     itxt t k' = WL.parens (WL.text t <+> WL.colon <+> WL.text (Text.unpack k'))

--- a/src/Waargonaut/Decode/ZipperMove.hs
+++ b/src/Waargonaut/Decode/ZipperMove.hs
@@ -27,6 +27,7 @@ data ZipperMove
   | Item Text
   | L Natural
   | R Natural
+  | BranchFail Text
   deriving (Show, Eq)
 
 -- | Pretty print a given zipper movement, used when printing
@@ -41,6 +42,7 @@ ppZipperMove m = case m of
 
   (DAt k)  -> WL.text "into\\" <+> itxt "key" k
   (Item t) -> WL.text "-::" <+> itxt "item" t
+  (BranchFail t) -> WL.text "(attempted: " <+> ntxt t <+> WL.text ")"
   where
     itxt t k' = WL.parens (WL.text t <+> WL.colon <+> WL.text (Text.unpack k'))
     ntxt n'   = WL.parens (WL.char 'i' <+> WL.char '+' <+> WL.text (show n'))

--- a/test/Decoder/Laws.hs
+++ b/test/Decoder/Laws.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE FlexibleInstances #-}
+module Decoder.Laws (decoderLaws) where
+
+import           Control.Applicative     (liftA3, empty, pure, (<|>))
+
+import           Data.Functor.Identity   (Identity)
+
+import           Test.Tasty              (TestTree, testGroup)
+import           Test.Tasty.Hedgehog     (testProperty)
+
+import           Hedgehog
+-- import qualified Hedgehog.Function       as Fn
+import qualified Hedgehog.Gen            as Gen
+-- import qualified Hedgehog.Range          as Range
+
+import qualified Waargonaut.Decode       as D
+import           Waargonaut.Decode.Error (DecodeError)
+import           Waargonaut.Decode.Types (Decoder)
+
+import           Types.Common            (parseBS)
+
+runD :: Decoder Identity a -> Either (DecodeError, D.CursorHistory) a
+runD d = D.runPureDecode d parseBS (D.mkCursor "true")
+
+-- identity
+decoder_alternative_id :: Property
+decoder_alternative_id = property $ do
+  a <- forAll Gen.bool
+
+  runD (empty <|> pure a) === pure a
+  runD (pure a <|> empty) === pure a
+
+-- associativity
+decoder_alternative_associativity :: Property
+decoder_alternative_associativity = property $ do
+  (a,b,c) <- forAll (liftA3 (,,) Gen.bool Gen.bool Gen.bool)
+
+  let
+    dA = pure a
+    dB = pure b
+    dC = pure c
+
+  -- (a <|> b) <|> c = a <|> (b <|> c)
+  runD ((dA <|> dB) <|> dC) === runD (dA <|> (dB <|> dC))
+
+-- | Applicative Laws
+--
+-- identity
+--
+--     pure id <*> v = v
+applicative_id :: Property
+applicative_id = property $ do
+  a <- pure <$> forAll Gen.bool
+
+  pure id <*> pure a ==
+
+
+--
+-- composition
+--
+--     pure (.) <*> u <*> v <*> w = u <*> (v <*> w)
+--
+-- homomorphism
+--
+--     pure f <*> pure x = pure (f x)
+--
+-- interchange
+--
+--     u <*> pure y = pure ($ y) <*> u
+
+decoderLaws :: TestTree
+decoderLaws = testGroup "Decoder Laws"
+  [ testProperty "Alternative 'identity'" decoder_alternative_id
+  , testProperty "Alternative 'associativity'" decoder_alternative_associativity
+  ]

--- a/test/Decoder/Laws.hs
+++ b/test/Decoder/Laws.hs
@@ -19,7 +19,7 @@ import qualified Hedgehog.Function       as Fn
 import qualified Hedgehog.Gen            as Gen
 
 import qualified Waargonaut.Decode       as D
-import           Waargonaut.Decode.Error (DecodeError (EmptyDecodeFailure))
+import           Waargonaut.Decode.Error (DecodeError (ConversionFailure))
 import           Waargonaut.Decode.Types (Decoder)
 
 import           Types.Common            (parseBS)
@@ -47,7 +47,7 @@ instance Show a => Show (ShowDecoder a) where
 genShowDecoder :: Gen a -> Gen (ShowDecoder a)
 genShowDecoder genA = Gen.choice
   [ SD . pure <$> genA
-  , SD <$> Gen.constant (throwError EmptyDecodeFailure)
+  , SD <$> Gen.constant (throwError $ ConversionFailure "Intentional DecodeError (TEST)")
   ]
 
 -- |

--- a/test/Encoder/Laws.hs
+++ b/test/Encoder/Laws.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes       #-}
+module Encoder.Laws (encoderLaws) where
+
+import           Test.Tasty            (TestTree, testGroup)
+import           Test.Tasty.Hedgehog   (testProperty)
+
+import           Data.ByteString.Lazy  (ByteString)
+import           Data.Functor.Identity (Identity)
+
+import           Hedgehog
+import           Hedgehog.Function     (Arg, Vary)
+import qualified Hedgehog.Function     as Fn
+import qualified Hedgehog.Gen          as Gen
+
+import           Waargonaut.Encode     (Encoder)
+import qualified Waargonaut.Encode     as E
+
+runSE :: ShowEncoder a -> a -> ByteString
+runSE (SE e) = E.simplePureEncodeNoSpaces e
+
+newtype ShowEncoder a = SE (Encoder Identity a)
+
+instance Show a => Show (ShowEncoder a) where
+  show (SE _) = "an encoder of type a"
+
+instance Fn.Contravariant ShowEncoder where
+  contramap f (SE a) = SE (Fn.contramap f a)
+
+-- |
+-- contravariant
+--
+--     contramap f . contramap g = contramap (g . f)
+contravariant_composition
+  :: forall f a.
+     ( Show f, Arg f, Vary f, Eq f
+     , Show a, Arg a, Vary a
+     )
+  => Gen f
+  -> Gen Bool
+  -> Gen a
+  -> Property
+contravariant_composition genF genG genA = property $ do
+  f <- Fn.forAllFn $ Fn.fn genF
+  g <- Fn.forAllFn $ Fn.fn genG
+
+  let ea = SE E.bool
+
+  a <- forAll genA
+
+  runSE (Fn.contramap f $ Fn.contramap g ea) a === runSE (Fn.contramap (g . f) ea) a
+
+contravariant_identity :: Property
+contravariant_identity = property $ do
+  a <- forAll Gen.bool
+
+  let ea = SE E.bool
+
+  runSE (Fn.contramap id ea) a === runSE ea a
+
+encoderLaws :: TestTree
+encoderLaws = testGroup "Encoder Laws"
+  [ testProperty "Contravariant 'composition'" $ contravariant_composition Gen.bool Gen.bool Gen.bool
+  , testProperty "Contravariant 'identity'" contravariant_identity
+  ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -52,6 +52,7 @@ import qualified Types.Whitespace            as WS
 import qualified Decoder
 import qualified Decoder.Laws
 import qualified Encoder
+import qualified Encoder.Laws
 
 encodeText
   :: Json
@@ -246,6 +247,8 @@ main = defaultMain $ testGroup "Waargonaut All Tests"
   , regressionTests
 
   , Decoder.decoderTests
-  , Decoder.Laws.decoderLaws
   , Encoder.encoderTests
+
+  , Decoder.Laws.decoderLaws
+  , Encoder.Laws.encoderLaws
   ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -50,6 +50,7 @@ import qualified Types.Json                  as J
 import qualified Types.Whitespace            as WS
 
 import qualified Decoder
+import qualified Decoder.Laws
 import qualified Encoder
 
 encodeText
@@ -245,5 +246,6 @@ main = defaultMain $ testGroup "Waargonaut All Tests"
   , regressionTests
 
   , Decoder.decoderTests
+  , Decoder.Laws.decoderLaws
   , Encoder.encoderTests
   ]

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -130,6 +130,7 @@ library
                      , hw-rankselect       >= 0.10    && < 0.13
                      , hw-bits             >= 0.7     && < 0.8
                      , tagged              >= 0.8.6   && < 0.9
+                     , semigroupoids       >= 5.2.2   && < 6
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -193,6 +194,8 @@ test-suite waarg-tests
                      , scientific             >= 0.3    && < 0.4
                      , tagged                 >= 0.8.6  && < 0.9
                      , mtl                    >= 2.2.2  && < 3
+                     , semigroupoids          >= 5.2.2  && < 6
+                     , containers             >= 0.5.6  && < 0.7
  
 
                      , waargonaut

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.2.0.1
+version:             0.2.0.3
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling
@@ -118,7 +118,7 @@ library
                      , hoist-error         >= 0.2     && < 0.3
                      , containers          >= 0.5.6   && < 0.7
                      , witherable          >= 0.2     && < 0.3
-                     , generics-sop        >= 0.3.2   && < 4
+                     , generics-sop        >= 0.3.2   && < 0.4
                      , mmorph              >= 1.1     && < 2
                      , transformers        >= 0.4     && < 0.6
                      , bifunctors          >= 5       && < 6

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -168,7 +168,9 @@ test-suite waarg-tests
 
                      , Utils
                      , Encoder
+                     , Encoder.Laws
                      , Decoder
+                     , Decoder.Laws
 
   type:                exitcode-stdio-1.0
   main-is:             Main.hs

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.2.0.3
+version:             0.2.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -178,6 +178,7 @@ test-suite waarg-tests
                      , tasty-hunit            >= 0.10   && < 0.11
                      , tasty-expected-failure >= 0.11   && < 0.12
                      , hedgehog               >= 0.6    && < 0.7
+                     , hedgehog-fn            >= 0.6    && < 0.7
                      , tasty-hedgehog         >= 0.2    && < 0.3
                      , lens                   >= 4.15   && < 5
                      , distributive           >= 0.5    && < 0.7
@@ -191,6 +192,7 @@ test-suite waarg-tests
                      , attoparsec             >= 0.13   && < 0.15
                      , scientific             >= 0.3    && < 0.4
                      , tagged                 >= 0.8.6  && < 0.9
+                     , mtl                    >= 2.2.2  && < 3
  
 
                      , waargonaut

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.2.0.1";
+  version = "0.2.0.3";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -1,11 +1,12 @@
 { mkDerivation, attoparsec, base, bifunctors, bytestring, Cabal
 , cabal-doctest, containers, contravariant, digit, directory
 , distributive, doctest, errors, filepath, generics-sop, hedgehog
-, hoist-error, hw-balancedparens, hw-bits, hw-json, hw-prim
-, hw-rankselect, lens, mmorph, mtl, nats, parsers, scientific
-, semigroups, stdenv, tagged, tasty, tasty-expected-failure
-, tasty-hedgehog, tasty-hunit, template-haskell, text, transformers
-, vector, witherable, wl-pprint-annotated, zippers
+, hedgehog-fn, hoist-error, hw-balancedparens, hw-bits, hw-json
+, hw-prim, hw-rankselect, lens, mmorph, mtl, nats, parsers
+, scientific, semigroups, stdenv, tagged, tasty
+, tasty-expected-failure, tasty-hedgehog, tasty-hunit
+, template-haskell, text, transformers, vector, witherable
+, wl-pprint-annotated, zippers
 }:
 mkDerivation {
   pname = "waargonaut";
@@ -21,9 +22,9 @@ mkDerivation {
   ];
   testHaskellDepends = [
     attoparsec base bytestring digit directory distributive doctest
-    filepath generics-sop hedgehog lens scientific semigroups tagged
-    tasty tasty-expected-failure tasty-hedgehog tasty-hunit
-    template-haskell text vector zippers
+    filepath generics-sop hedgehog hedgehog-fn lens mtl scientific
+    semigroups tagged tasty tasty-expected-failure tasty-hedgehog
+    tasty-hunit template-haskell text vector zippers
   ];
   homepage = "https://github.com/qfpl/waargonaut";
   description = "JSON wrangling";

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.2.0.3";
+  version = "0.2.1.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -3,7 +3,7 @@
 , distributive, doctest, errors, filepath, generics-sop, hedgehog
 , hedgehog-fn, hoist-error, hw-balancedparens, hw-bits, hw-json
 , hw-prim, hw-rankselect, lens, mmorph, mtl, nats, parsers
-, scientific, semigroups, stdenv, tagged, tasty
+, scientific, semigroupoids, semigroups, stdenv, tagged, tasty
 , tasty-expected-failure, tasty-hedgehog, tasty-hunit
 , template-haskell, text, transformers, vector, witherable
 , wl-pprint-annotated, zippers
@@ -17,14 +17,15 @@ mkDerivation {
     base bifunctors bytestring containers contravariant digit
     distributive errors generics-sop hoist-error hw-balancedparens
     hw-bits hw-json hw-prim hw-rankselect lens mmorph mtl nats parsers
-    scientific semigroups tagged text transformers vector witherable
-    wl-pprint-annotated zippers
+    scientific semigroupoids semigroups tagged text transformers vector
+    witherable wl-pprint-annotated zippers
   ];
   testHaskellDepends = [
-    attoparsec base bytestring digit directory distributive doctest
-    filepath generics-sop hedgehog hedgehog-fn lens mtl scientific
-    semigroups tagged tasty tasty-expected-failure tasty-hedgehog
-    tasty-hunit template-haskell text vector zippers
+    attoparsec base bytestring containers digit directory distributive
+    doctest filepath generics-sop hedgehog hedgehog-fn lens mtl
+    scientific semigroupoids semigroups tagged tasty
+    tasty-expected-failure tasty-hedgehog tasty-hunit template-haskell
+    text vector zippers
   ];
   homepage = "https://github.com/qfpl/waargonaut";
   description = "JSON wrangling";


### PR DESCRIPTION
Added `MonadError` instance for `Decoder` to let you do these sorts of shenanigans:

```haskell
data MyEnum
  = A
  | B
  | C
  deriving (Eq, Show)

decodeMyEnum :: Monad f => D.Decoder f MyEnum
decodeMyEnum = D.text >>= \case
  "a" -> pure A
  "b" -> pure B
  "c" -> pure C
  _   -> throwError (D.ConversionFailure "MyEnum")
```
Also added an `Alt` instance for `Decoder` for these shenanigans:

```haskell
decodeEitherAlt :: Monad f => D.Decoder f (Either Text Int)
decodeEitherAlt = (Left <$> D.text) <!> (Right <$> D.int)
```

Went overboard adding some laws checks for the encoder and decoder structures to ensure the typeclass implementations are law abiding.

Have to stop adding things and just get this merged...