### PR TITLE
Prevent bottom on `manyMoves`.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for waargonaut
 
+## 0.3.0.0  -- 2018-11-14
+
+* Change to use the `natural` package for `Natural` numbers.
+
 ## 0.2.1.0  -- 2018-11-13
 
 * Add `MonadError` and `Alt` instance for `Decoder`

--- a/src/Waargonaut/Decode.hs
+++ b/src/Waargonaut/Decode.hs
@@ -120,17 +120,15 @@ import           Data.Monoid                               (mempty)
 
 import           Data.Scientific                           (Scientific)
 
-import           Data.List                                 (replicate)
 import           Data.List.NonEmpty                        (NonEmpty ((:|)))
 import           Data.Maybe                                (Maybe (..),
                                                             fromMaybe, maybe)
+import           Natural                                   (Natural, replicate, zero', successor')
 
 import           Data.Text                                 (Text)
 
 import           Data.ByteString.Char8                     (ByteString)
 import qualified Data.ByteString.Char8                     as BS8
-
-import           Numeric.Natural                           (Natural)
 
 import           Waargonaut.Types
 
@@ -212,7 +210,7 @@ cursorRankL = lens JC.cursorRank (\c r -> c { cursorRank = r })
 
 -- | Execute the given function 'n' times'.
 manyMoves :: Monad m => Natural -> (b -> m b) -> b -> m b
-manyMoves i g = foldl (>=>) pure (replicate (fromIntegral i) g)
+manyMoves i g = foldl (>=>) pure (replicate i g)
 
 -- | Generalise a 'Decoder' that has been specialised to 'Identity' back to some 'Monad f'.
 generaliseDecoder :: Monad f => Decoder Identity a -> Decoder f a
@@ -320,7 +318,7 @@ moveRight1
   => JCurs
   -> DecodeResult f JCurs
 moveRight1 =
-  moveRightN 1
+  moveRightN (successor' zero')
 
 -- | Helper function to move left once.
 --
@@ -432,7 +430,7 @@ moveToKey k c = do
     -- Then move into the THING at the key
     then recordRank (DAt k) c >> moveRight1 c
     -- Try jump to the next key index
-    else ( DI.try (moveRightN 2 c) <!?> (_KeyNotFound # k) ) >>= moveToKey k
+    else ( DI.try (moveRightN (successor' (successor' zero')) c) <!?> (_KeyNotFound # k) ) >>= moveToKey k
 
 -- | Move to the first occurence of this key, as per 'moveToKey' and then
 -- attempt to run the given 'Decoder' on that value, returning the result.

--- a/src/Waargonaut/Decode/Traversal.hs
+++ b/src/Waargonaut/Decode/Traversal.hs
@@ -79,10 +79,11 @@ module Waargonaut.Decode.Traversal
 
 import           Prelude                       hiding (either, maybe, null)
 
-import           Numeric.Natural               (Natural)
+import           Natural                       (Natural, successor', zero',
+                                                _Natural)
 
 import           Control.Lens                  (Bazaar', Cons, LensLike', Snoc,
-                                                (^.), (^?))
+                                                re, (^.), (^?))
 import qualified Control.Lens                  as L
 
 import           Control.Lens.Internal.Indexed (Indexed, Indexing)
@@ -331,7 +332,7 @@ moveLeftN
   -> JCursor h a
   -> DecodeResult f (JCursor h a)
 moveLeftN n cur =
-  moveAndKeepHistory (L n) (Z.jerks Z.leftward (fromIntegral n) cur)
+  moveAndKeepHistory (L n) (Z.jerks Z.leftward (n ^. re _Natural) cur)
 
 -- | From the current cursor location, try to move 'n' steps to the right.
 moveRightN
@@ -340,7 +341,7 @@ moveRightN
   -> JCursor h a
   -> DecodeResult f (JCursor h a)
 moveRightN n cur =
-  moveAndKeepHistory (R n) (Z.jerks Z.rightward (fromIntegral n) cur)
+  moveAndKeepHistory (R n) (Z.jerks Z.rightward (n ^. re _Natural) cur)
 
 -- | From the current cursor location, try to move 1 step to the left.
 moveLeft1
@@ -348,7 +349,7 @@ moveLeft1
   => JCursor h a
   -> DecodeResult f (JCursor h a)
 moveLeft1 =
-  moveLeftN 1
+  moveLeftN (successor' zero')
 
 -- | From the current cursor location, try to move 1 step to the right.
 moveRight1
@@ -356,7 +357,7 @@ moveRight1
   => JCursor h a
   -> DecodeResult f (JCursor h a)
 moveRight1 =
-  moveRightN 1
+  moveRightN (successor' zero')
 
 -- | Provide a 'conversion' function and create a 'Decoder' that uses the
 -- current cursor and runs the given function. Fails with 'ConversionFailure' and

--- a/src/Waargonaut/Decode/ZipperMove.hs
+++ b/src/Waargonaut/Decode/ZipperMove.hs
@@ -12,7 +12,7 @@ import qualified Control.Lens                  as L
 import           Data.Text                     (Text)
 import qualified Data.Text                     as Text
 
-import           Numeric.Natural               (Natural)
+import           Natural                       (Natural)
 
 import           Text.PrettyPrint.Annotated.WL (Doc, (<+>))
 import qualified Text.PrettyPrint.Annotated.WL as WL

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -26,6 +26,8 @@ import qualified Data.Sequence              as Seq
 import           Data.Tagged                (untag)
 import           Data.Text                  (Text)
 
+import qualified Natural                    as N
+
 import           Waargonaut.Generic         (mkDecoder)
 
 import           Waargonaut.Decode.Internal (ZipperMove (BranchFail),
@@ -102,7 +104,7 @@ decodeTest3Json = assertBool "(Char,String,[Int]) Decode Success" . Either.isRig
     decoder = D.withCursor $ D.down >=> \fstElem -> liftA3 (,,)
       (D.focus D.unboundedChar fstElem)
       (D.moveRight1 fstElem >>= D.focus D.string)
-      (D.moveRightN 2 fstElem >>= D.rightwardSnoc [] D.int)
+      (D.moveRightN (N.successor' (N.successor' N.zero')) fstElem >>= D.rightwardSnoc [] D.int)
 
 data MyEnum
   = A

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.2.1.0
+version:             0.3.0.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling
@@ -131,6 +131,7 @@ library
                      , hw-bits             >= 0.7     && < 0.8
                      , tagged              >= 0.8.6   && < 0.9
                      , semigroupoids       >= 5.2.2   && < 6
+                     , natural             >= 0.3     && < 4
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -198,7 +199,7 @@ test-suite waarg-tests
                      , mtl                    >= 2.2.2  && < 3
                      , semigroupoids          >= 5.2.2  && < 6
                      , containers             >= 0.5.6  && < 0.7
- 
+                     , natural                >= 0.3    && < 4
 
                      , waargonaut
 

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -2,7 +2,7 @@
 , cabal-doctest, containers, contravariant, digit, directory
 , distributive, doctest, errors, filepath, generics-sop, hedgehog
 , hedgehog-fn, hoist-error, hw-balancedparens, hw-bits, hw-json
-, hw-prim, hw-rankselect, lens, mmorph, mtl, nats, parsers
+, hw-prim, hw-rankselect, lens, mmorph, mtl, nats, natural, parsers
 , scientific, semigroupoids, semigroups, stdenv, tagged, tasty
 , tasty-expected-failure, tasty-hedgehog, tasty-hunit
 , template-haskell, text, transformers, vector, witherable
@@ -10,19 +10,19 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.2.1.0";
+  version = "0.3.0.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [
     base bifunctors bytestring containers contravariant digit
     distributive errors generics-sop hoist-error hw-balancedparens
-    hw-bits hw-json hw-prim hw-rankselect lens mmorph mtl nats parsers
-    scientific semigroupoids semigroups tagged text transformers vector
-    witherable wl-pprint-annotated zippers
+    hw-bits hw-json hw-prim hw-rankselect lens mmorph mtl nats natural
+    parsers scientific semigroupoids semigroups tagged text
+    transformers vector witherable wl-pprint-annotated zippers
   ];
   testHaskellDepends = [
     attoparsec base bytestring containers digit directory distributive
-    doctest filepath generics-sop hedgehog hedgehog-fn lens mtl
+    doctest filepath generics-sop hedgehog hedgehog-fn lens mtl natural
     scientific semigroupoids semigroups tagged tasty
     tasty-expected-failure tasty-hedgehog tasty-hunit template-haskell
     text vector zippers


### PR DESCRIPTION
Fixes #23

The `Natural` type in use for the `manyMoves` function could far too easily allow exceptions. The implementation of `Natural` in the `natural` package does not, and has some nice
built in functions for building up smaller numbers.