### PR TITLE
API Panel Beating

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 * Fixed bug in documentation for `atKey`
 * Added `_MapLikeObj` `Prism`
 * Added some optics into object / maplikeobj keys
+* Fixed bug in `maybeOrNull` decoder to be more strict in what it accepts
+* Rewrote `either` decoder in terms of the alternative instance to allow for better errors
 
 ## 0.3.0.0  -- 2018-11-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Revision history for waargonaut
 
+## 0.4.0.0  -- 2018-11-19
+
+* Redesign & rebuild of `Encoder` internals to allow for greater control and flexibility
+* Factor our law tests into their own module (a recheck of these tests is needed)
+* Fixed bug in `list` and `nonempty` decoders
+* Fixed bug in `foldCursor` function
+* Fixed bug in `Cons` instance for `CommaSep`
+* Fixed bug in documentation for `atKey`
+* Added `_MapLikeObj` `Prism`
+* Added some optics into object / maplikeobj keys
+
 ## 0.3.0.0  -- 2018-11-14
 
 * Change to use the `natural` package for `Natural` numbers.

--- a/src/Waargonaut/Decode.hs
+++ b/src/Waargonaut/Decode.hs
@@ -466,8 +466,8 @@ fromKey k d =
 --
 -- myRecDecoder :: Decoder f MyRec
 -- myRecDecoder = MyRec
---   <$> atKey "field_a" text
---   <*> atKey "field_b" int
+--   \<$> atKey "field_a" text
+--   \<*> atKey "field_b" int
 -- @
 --
 atKey
@@ -705,8 +705,9 @@ nonemptyAt
   -> DecodeResult f (NonEmpty a)
 nonemptyAt elemD = down >=> \curs -> do
   h <- focus elemD curs
-  xs <- moveRight1 curs
-  (h :|) <$> rightwardSnoc [] elemD xs
+  DI.try (moveRight1 curs) >>= maybe
+    (pure $ h :| [])
+    (fmap (h :|) . rightwardSnoc [] elemD)
 
 -- | Helper to create a 'NonEmpty a' 'Decoder'.
 nonempty :: Monad f => Decoder f a -> Decoder f (NonEmpty a)

--- a/src/Waargonaut/Decode.hs
+++ b/src/Waargonaut/Decode.hs
@@ -114,6 +114,7 @@ import           Data.Foldable                             (foldl)
 import           Data.Function                             (const, flip, ($),
                                                             (&))
 import           Data.Functor                              (fmap, (<$), (<$>))
+import           Data.Functor.Alt                          ((<!>))
 import           Data.Functor.Identity                     (Identity,
                                                             runIdentity)
 import           Data.Monoid                               (mempty)
@@ -123,7 +124,8 @@ import           Data.Scientific                           (Scientific)
 import           Data.List.NonEmpty                        (NonEmpty ((:|)))
 import           Data.Maybe                                (Maybe (..),
                                                             fromMaybe, maybe)
-import           Natural                                   (Natural, replicate, zero', successor')
+import           Natural                                   (Natural, replicate,
+                                                            successor', zero')
 
 import           Data.Text                                 (Text)
 
@@ -736,7 +738,7 @@ withDefault
   -> Decoder f (Maybe a)
   -> Decoder f a
 withDefault def hasD =
-  withCursor (fmap (fromMaybe def) . focus hasD)
+  fromMaybe def <$> hasD
 
 -- | Named to match it's 'Encoder' counterpart, this function will decode an
 -- optional value.
@@ -745,7 +747,7 @@ maybeOrNull
   => Decoder f a
   -> Decoder f (Maybe a)
 maybeOrNull a =
-  withCursor (DI.try . focus a)
+  (Nothing <$ null) <!> (Just <$> a)
 
 -- | Decode either an 'a' or a 'b', failing if neither 'Decoder' succeeds. The
 -- 'Right' decoder is attempted first.
@@ -755,6 +757,4 @@ either
   -> Decoder f b
   -> Decoder f (Either a b)
 either leftD rightD =
-  withCursor $ \c ->
-    DI.try (focus (Right <$> rightD) c) >>=
-    maybe (focus (Left <$> leftD) c) pure
+  (Left <$> leftD) <!> (Right <$> rightD)

--- a/src/Waargonaut/Decode/Internal.hs
+++ b/src/Waargonaut/Decode/Internal.hs
@@ -329,10 +329,11 @@ foldCursor' empty scons mvCurs elemD =
   go empty
   where
     go acc cur = do
-      me <- fmap (scons acc) <$> try (runDecoder' elemD cur)
-      maybe (pure acc)
-        (\r -> try (mvCurs cur) >>= maybe (pure r) (go r))
-        me
+      acc' <- scons acc <$> runDecoder' elemD cur
+
+      try (mvCurs cur) >>= maybe
+        (pure acc')
+        (go acc')
 
 -- |
 -- Provide a generalised and low level way of turning a JSON object into a

--- a/src/Waargonaut/Encode/Types.hs
+++ b/src/Waargonaut/Encode/Types.hs
@@ -1,15 +1,26 @@
-{-# LANGUAGE FlexibleInstances     #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NoImplicitPrelude     #-}
-{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+-- |
+-- Types and functions that make up the internal structure of the encoders.
+--
 module Waargonaut.Encode.Types
-  ( Encoder (..)
+  ( -- * Types
+    EncoderFns (..)
+
+    -- * Useful aliases
+  , Encoder
   , Encoder'
-  , ObjEncoder (..)
+  , ObjEncoder
   , ObjEncoder'
-  , AsEncoder (..)
-  , generaliseEncoder'
-  , generaliseObjEncoder'
+
+    -- * Runners
+  , runEncoder
+  , runPureEncoder
+
+    -- * Helpers
+  , jsonEncoder
+  , objEncoder
+  , generaliseEncoder
   ) where
 
 import           Control.Monad                        (Monad)
@@ -18,12 +29,12 @@ import           Control.Monad.Morph                  (MFunctor (..),
 
 import           Control.Applicative                  (Applicative, liftA2,
                                                        pure)
-import           Control.Category                     ((.))
+import           Control.Category                     (id, (.))
 import           Control.Lens                         (( # ))
 
 import           Data.Either                          (either)
 import           Data.Function                        (const, ($))
-import           Data.Functor                         ((<$>))
+import           Data.Functor                         (Functor)
 import           Data.Functor.Contravariant           (Contravariant (..))
 
 import           Data.Functor.Contravariant.Divisible (Decidable (..),
@@ -37,77 +48,82 @@ import           Data.Functor.Identity                (Identity (..))
 
 import           Waargonaut.Types                     (JObject, Json, WS, _JObj)
 
+
 -- |
 -- Define an "encoder" as a function from some @a@ to some 'Json' with the
 -- allowance for some context @f@.
 --
-newtype Encoder f a = Encoder
-  { runEncoder :: a -> f Json -- ^ Run this 'Encoder' to convert the 'a' to 'Json'
+-- The helper functions 'jsonEncoder' and 'objEncoder' are probably what you
+-- want to use.
+--
+data EncoderFns i f a = EncoderFns
+  { finaliseEncoding :: i -> Json -- ^ The @i@ need not be the final 'Json' structure. This function will complete the output from 'initialEncoding' to the final 'Json' output.
+
+  , initialEncoding  :: a -> f i -- ^ Run the initial encoding step of the given input. This lets you encode the @a@ to an intermediate structure before utilising the 'finaliseEncoding' function to complete the process.
   }
 
-instance Contravariant (Encoder f) where
-  contramap f (Encoder g) = Encoder (g . f)
+instance MFunctor (EncoderFns i) where
+  hoist nat (EncoderFns f i) = EncoderFns f (nat . i)
 
-instance MFunctor Encoder where
-  hoist nat (Encoder eFn) = Encoder (nat . eFn)
+-- | Generalise any 'Encoder' a' to 'Encoder f a'
+generaliseEncoder :: Monad f => EncoderFns i Identity a -> EncoderFns i f a
+generaliseEncoder (EncoderFns f i) = EncoderFns f (generalize . i)
 
--- | Generalise an 'Encoder' a' to 'Encoder f a'
-generaliseEncoder' :: Monad f => Encoder' a -> Encoder f a
-generaliseEncoder' = Encoder . fmap generalize . runEncoder
-{-# INLINE generaliseEncoder' #-}
-
--- |
--- As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
-type Encoder' = Encoder Identity
-
--- |
-newtype ObjEncoder f a = ObjEncoder
-  { runObjEncoder :: a -> f (JObject WS Json)
-  }
-
--- |
--- As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
-type ObjEncoder' = ObjEncoder Identity
-
-instance Contravariant (ObjEncoder f) where
-  contramap f (ObjEncoder g) = ObjEncoder (g . f)
+instance Contravariant (EncoderFns o f) where
+  contramap f e = EncoderFns (finaliseEncoding e) (initialEncoding e . f)
   {-# INLINE contramap #-}
 
-instance Applicative f => Divisible (ObjEncoder f) where
-  conquer = ObjEncoder (const (pure mempty))
+instance Applicative f => Divisible (EncoderFns (JObject WS Json) f) where
+  conquer = objEncoder (const (pure mempty))
   {-# INLINE conquer #-}
 
-  divide atobc objB objC = ObjEncoder $ \a ->
+  divide atobc (EncoderFns _ oB) (EncoderFns _ oC) = objEncoder $ \a ->
     let
       (b,c) = atobc a
     in
-      liftA2 (<>) (runObjEncoder objB b) (runObjEncoder objC c)
+      liftA2 (<>) (oB b) (oC c)
   {-# INLINE divide #-}
 
-instance Applicative f => Decidable (ObjEncoder f) where
-  lose f = ObjEncoder $ \a -> absurd (f a)
+instance Applicative f => Decidable (EncoderFns (JObject WS Json) f) where
+  lose f = objEncoder $ \a -> absurd (f a)
   {-# INLINE lose #-}
 
-  choose split objB objC = ObjEncoder $ \a ->
-    either (runObjEncoder objB) (runObjEncoder objC) (split a)
+  choose split (EncoderFns _ oB) (EncoderFns _ oC) = objEncoder $ \a ->
+    either oB oC (split a)
   {-# INLINE choose #-}
 
-instance MFunctor ObjEncoder where
-  hoist nat (ObjEncoder eFn) = ObjEncoder (nat . eFn)
-  {-# INLINE hoist #-}
+-- | As a convenience, this type defines the @i@ to be a specific 'Json' structure:
+type Encoder f a = EncoderFns Json f a
 
--- | Generalise an 'ObjEncoder' a' to 'ObjEncoder f a'
-generaliseObjEncoder' :: Monad f => ObjEncoder' a -> ObjEncoder f a
-generaliseObjEncoder' = ObjEncoder . fmap generalize . runObjEncoder
-{-# INLINE generaliseObjEncoder' #-}
+-- | As a convenience, this type defines the @i@ to be a specific 'JObject WS Json' structure:
+type ObjEncoder f a = EncoderFns (JObject WS Json) f a
 
-class AsEncoder e f where
-  runToJson :: forall a. e f a -> a -> f Json
+-- | As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
+type Encoder' a = EncoderFns Json Identity a
+-- | As a convenience, this type is a pure ObjEncoder over 'Identity' in place of the @f@.
+type ObjEncoder' a = EncoderFns (JObject WS Json) Identity a
 
-instance Applicative f => AsEncoder Encoder f where
-  runToJson = runEncoder
-  {-# INLINE runToJson #-}
+-- | Run any encoder to the 'Json' representation, allowing for some
+-- 'Applicative' context @f@.
+runEncoder :: Functor f => EncoderFns i f a -> a -> f Json
+runEncoder e = fmap (finaliseEncoding e) . initialEncoding e
+{-# INLINE runEncoder #-}
 
-instance Applicative f => AsEncoder ObjEncoder f where
-  runToJson (ObjEncoder enc) a = (\o' -> _JObj # (o', mempty)) <$> enc a
-  {-# INLINE runToJson #-}
+-- | Run any encoder to the 'Json' representation, with the context specialised
+-- to 'Identity' for convenience.
+runPureEncoder :: EncoderFns i Identity a -> a -> Json
+runPureEncoder e = runIdentity . fmap (finaliseEncoding e) . initialEncoding e
+{-# INLINE runPureEncoder #-}
+
+-- | Helper function for creating an 'Encoder', provides the default
+-- 'finaliseEncoding' function for 'Json' encoders.
+jsonEncoder :: (a -> f Json) -> EncoderFns Json f a
+jsonEncoder = EncoderFns id
+{-# INLINE jsonEncoder #-}
+
+-- | Helper function for creating a JSON 'object' 'Encoder'. Provides the
+-- default 'finaliseEncoding' function for completing the 'JObject' to the
+-- necessary 'Json' type.
+objEncoder :: (a -> f (JObject WS Json)) -> EncoderFns (JObject WS Json) f a
+objEncoder = EncoderFns (\o -> _JObj # (o, mempty))
+{-# INLINE objEncoder #-}

--- a/src/Waargonaut/Encode/Types.hs
+++ b/src/Waargonaut/Encode/Types.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE FlexibleInstances     #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoImplicitPrelude     #-}
+{-# LANGUAGE RankNTypes #-}
+module Waargonaut.Encode.Types
+  ( Encoder (..)
+  , Encoder'
+  , ObjEncoder (..)
+  , ObjEncoder'
+  , AsEncoder (..)
+  , generaliseEncoder'
+  , generaliseObjEncoder'
+  ) where
+
+import           Control.Monad                        (Monad)
+import           Control.Monad.Morph                  (MFunctor (..),
+                                                       generalize)
+
+import           Control.Applicative                  (Applicative, liftA2,
+                                                       pure)
+import           Control.Category                     ((.))
+import           Control.Lens                         (( # ))
+
+import           Data.Either                          (either)
+import           Data.Function                        (const, ($))
+import           Data.Functor                         ((<$>))
+import           Data.Functor.Contravariant           (Contravariant (..))
+
+import           Data.Functor.Contravariant.Divisible (Decidable (..),
+                                                       Divisible (..))
+import           Data.Monoid                          (mempty)
+import           Data.Semigroup                       ((<>))
+import           Data.Void                            (absurd)
+
+import           Data.Functor                         (fmap)
+import           Data.Functor.Identity                (Identity (..))
+
+import           Waargonaut.Types                     (JObject, Json, WS, _JObj)
+
+-- |
+-- Define an "encoder" as a function from some @a@ to some 'Json' with the
+-- allowance for some context @f@.
+--
+newtype Encoder f a = Encoder
+  { runEncoder :: a -> f Json -- ^ Run this 'Encoder' to convert the 'a' to 'Json'
+  }
+
+instance Contravariant (Encoder f) where
+  contramap f (Encoder g) = Encoder (g . f)
+
+instance MFunctor Encoder where
+  hoist nat (Encoder eFn) = Encoder (nat . eFn)
+
+-- | Generalise an 'Encoder' a' to 'Encoder f a'
+generaliseEncoder' :: Monad f => Encoder' a -> Encoder f a
+generaliseEncoder' = Encoder . fmap generalize . runEncoder
+{-# INLINE generaliseEncoder' #-}
+
+-- |
+-- As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
+type Encoder' = Encoder Identity
+
+-- |
+newtype ObjEncoder f a = ObjEncoder
+  { runObjEncoder :: a -> f (JObject WS Json)
+  }
+
+-- |
+-- As a convenience, this type is a pure Encoder over 'Identity' in place of the @f@.
+type ObjEncoder' = ObjEncoder Identity
+
+instance Contravariant (ObjEncoder f) where
+  contramap f (ObjEncoder g) = ObjEncoder (g . f)
+  {-# INLINE contramap #-}
+
+instance Applicative f => Divisible (ObjEncoder f) where
+  conquer = ObjEncoder (const (pure mempty))
+  {-# INLINE conquer #-}
+
+  divide atobc objB objC = ObjEncoder $ \a ->
+    let
+      (b,c) = atobc a
+    in
+      liftA2 (<>) (runObjEncoder objB b) (runObjEncoder objC c)
+  {-# INLINE divide #-}
+
+instance Applicative f => Decidable (ObjEncoder f) where
+  lose f = ObjEncoder $ \a -> absurd (f a)
+  {-# INLINE lose #-}
+
+  choose split objB objC = ObjEncoder $ \a ->
+    either (runObjEncoder objB) (runObjEncoder objC) (split a)
+  {-# INLINE choose #-}
+
+instance MFunctor ObjEncoder where
+  hoist nat (ObjEncoder eFn) = ObjEncoder (nat . eFn)
+  {-# INLINE hoist #-}
+
+-- | Generalise an 'ObjEncoder' a' to 'ObjEncoder f a'
+generaliseObjEncoder' :: Monad f => ObjEncoder' a -> ObjEncoder f a
+generaliseObjEncoder' = ObjEncoder . fmap generalize . runObjEncoder
+{-# INLINE generaliseObjEncoder' #-}
+
+class AsEncoder e f where
+  runToJson :: forall a. e f a -> a -> f Json
+
+instance Applicative f => AsEncoder Encoder f where
+  runToJson = runEncoder
+  {-# INLINE runToJson #-}
+
+instance Applicative f => AsEncoder ObjEncoder f where
+  runToJson (ObjEncoder enc) a = (\o' -> _JObj # (o', mempty)) <$> enc a
+  {-# INLINE runToJson #-}

--- a/src/Waargonaut/Types/CommaSep.hs
+++ b/src/Waargonaut/Types/CommaSep.hs
@@ -39,8 +39,8 @@ module Waargonaut.Types.CommaSep
   , unconsCommaSep
   ) where
 
-import           Prelude                 (Eq, Int, Show (showsPrec), otherwise,
-                                          showString, shows, (&&), (<=), (==))
+import           Prelude                 (Eq, Int, Show (showsPrec),
+                                          showString, shows, (&&), (==), (||))
 
 import           Control.Applicative     (Applicative (..), liftA2, pure, (*>),
                                           (<*), (<*>))
@@ -318,12 +318,10 @@ instance Ixed (CommaSeparated ws a) where
 
   ix _ _ c@(CommaSeparated _ Nothing) = pure c
 
-  ix i f c@(CommaSeparated w (Just es))
-    | i == 0 && es ^. elemsElems . to V.null =
-      CommaSeparated w . Just <$> (es & elemsLast . traverse %%~ f)
-    | i <= es ^. elemsElems . to length =
-      CommaSeparated w . Just <$> (es & elemsElems . ix i . traverse %%~ f)
-    | otherwise = pure c
+  ix i f (CommaSeparated w (Just es)) = CommaSeparated w . Just <$>
+    if i == 0 && es ^. elemsElems . to V.null || i == es ^. elemsElems . to length
+    then es & elemsLast . traverse %%~ f
+    else es & elemsElems . ix i . traverse %%~ f
 
 -- | Convert a list of 'a' to a 'CommaSeparated' list, with no whitespace.
 fromList :: (Monoid ws, Semigroup ws) => [a] -> CommaSeparated ws a

--- a/src/Waargonaut/Types/JArray.hs
+++ b/src/Waargonaut/Types/JArray.hs
@@ -17,11 +17,11 @@ module Waargonaut.Types.JArray
   , jArrayBuilder
   ) where
 
-import           Prelude                   (Eq, Show)
+import           Prelude                   (Eq, Show, Int)
 
 import           Control.Category          ((.))
 import           Control.Error.Util        (note)
-import           Control.Lens              (AsEmpty (..), Cons (..), Rewrapped,
+import           Control.Lens              (AsEmpty (..), Cons (..), Rewrapped, Ixed (..), Index, IxValue,
                                             Wrapped (..), cons, isn't, iso,
                                             nearly, over, prism, to, ( # ),
                                             (^.), (^?), _2, _Wrapped)
@@ -83,6 +83,12 @@ instance (Monoid ws, Semigroup ws) => Semigroup (JArray ws a) where
 instance (Semigroup ws, Monoid ws) => Monoid (JArray ws a) where
   mempty = JArray mempty
   mappend = (<>)
+
+type instance IxValue (JArray ws a) = a
+type instance Index (JArray ws a)   = Int
+
+instance Ixed (JArray ws a) where
+  ix i f (JArray cs) = JArray <$> ix i f cs
 
 instance Bifunctor JArray where
   bimap f g (JArray cs) = JArray (bimap f g cs)

--- a/src/Waargonaut/Types/JObject.hs
+++ b/src/Waargonaut/Types/JObject.hs
@@ -30,17 +30,17 @@ module Waargonaut.Types.JObject
   , parseJObject
   ) where
 
-import           Prelude                   (Eq, Int, Show, elem, not, otherwise,
-                                            (==))
+import           Prelude                   (Eq, Int, Show, elem, fst, not,
+                                            otherwise, (==))
 
 import           Control.Applicative       ((<*), (<*>))
 import           Control.Category          (id, (.))
-import           Control.Lens              (AsEmpty (..), At (..), Index,
-                                            IxValue, Ixed (..), Lens', Prism,
-                                            Rewrapped, Wrapped (..), cons,
-                                            isn't, iso, nearly, re, to, ( # ),
-                                            (.~), (<&>), (^.), (^?),
-                                            _Unwrapping, _Wrapped)
+import           Control.Lens              (AsEmpty (..), At (..), Index, 
+                                            IxValue, Ixed (..), Lens', Prism',
+                                            Rewrapped, Wrapped (..), cons, 
+                                            isn't, iso, nearly, prism', re, to,
+                                            ( # ), (.~), (<&>), (^.), (^?),
+                                            _Wrapped)
 
 import           Control.Monad             (Monad)
 import           Data.Bifoldable           (Bifoldable (bifoldMap))
@@ -204,6 +204,9 @@ newtype MapLikeObj ws a = MLO
   }
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
+_MapLikeObj :: Monoid ws => Prism' (JObject ws a) (MapLikeObj ws a)
+_MapLikeObj = prism' fromMapLikeObj (Just . fst . toMapLikeObj)
+
 instance MapLikeObj ws a ~ t => Rewrapped (MapLikeObj ws a) t
 
 instance Wrapped (MapLikeObj ws a) where
@@ -224,9 +227,6 @@ instance Monoid ws => Ixed (MapLikeObj ws a) where
 instance Monoid ws => At (MapLikeObj ws a) where
   at k f (MLO (JObject cs)) = jAssocAlterF k f (find (textKeyMatch k) cs) <&>
     MLO . JObject . maybe (W.filter (not . textKeyMatch k) cs) (`cons` cs)
-
-_MapLikeObj :: Prism (JObject ws a) (JObject ws a) (MapLikeObj ws a) (MapLikeObj ws a)
-_MapLikeObj = _Unwrapping MLO
 
 instance Bifunctor MapLikeObj where
   bimap f g (MLO o) = MLO (bimap f g o)

--- a/src/Waargonaut/Types/JObject.hs
+++ b/src/Waargonaut/Types/JObject.hs
@@ -204,7 +204,13 @@ newtype MapLikeObj ws a = MLO
   }
   deriving (Eq, Show, Functor, Foldable, Traversable)
 
-_MapLikeObj :: Monoid ws => Prism' (JObject ws a) (MapLikeObj ws a)
+-- |
+-- 'Prism' for working with a 'JObject' as a 'MapLikeObj'. This optic will keep
+-- the first unique key on a given 'JObject' and this information is not
+-- recoverable. If you want to create a 'MapLikeObj' from a 'JObject' and keep
+-- what is removed, then use the 'toMapLikeObj' function.
+--
+_MapLikeObj :: (Semigroup ws, Monoid ws) => Prism' (JObject ws a) (MapLikeObj ws a)
 _MapLikeObj = prism' fromMapLikeObj (Just . fst . toMapLikeObj)
 
 instance MapLikeObj ws a ~ t => Rewrapped (MapLikeObj ws a) t

--- a/src/Waargonaut/Types/JObject.hs
+++ b/src/Waargonaut/Types/JObject.hs
@@ -23,6 +23,7 @@ module Waargonaut.Types.JObject
   , MapLikeObj
   , toMapLikeObj
   , fromMapLikeObj
+  , _MapLikeObj
 
     -- * Parser / Builder
   , jObjectBuilder
@@ -35,10 +36,11 @@ import           Prelude                   (Eq, Int, Show, elem, not, otherwise,
 import           Control.Applicative       ((<*), (<*>))
 import           Control.Category          (id, (.))
 import           Control.Lens              (AsEmpty (..), At (..), Index,
-                                            IxValue, Ixed (..), Lens',
+                                            IxValue, Ixed (..), Lens', Prism,
                                             Rewrapped, Wrapped (..), cons,
                                             isn't, iso, nearly, re, to, ( # ),
-                                            (.~), (<&>), (^.), (^?), _Wrapped)
+                                            (.~), (<&>), (^.), (^?),
+                                            _Unwrapping, _Wrapped)
 
 import           Control.Monad             (Monad)
 import           Data.Bifoldable           (Bifoldable (bifoldMap))
@@ -222,6 +224,9 @@ instance Monoid ws => Ixed (MapLikeObj ws a) where
 instance Monoid ws => At (MapLikeObj ws a) where
   at k f (MLO (JObject cs)) = jAssocAlterF k f (find (textKeyMatch k) cs) <&>
     MLO . JObject . maybe (W.filter (not . textKeyMatch k) cs) (`cons` cs)
+
+_MapLikeObj :: Prism (JObject ws a) (JObject ws a) (MapLikeObj ws a) (MapLikeObj ws a)
+_MapLikeObj = _Unwrapping MLO
 
 instance Bifunctor MapLikeObj where
   bimap f g (MLO o) = MLO (bimap f g o)

--- a/src/Waargonaut/Types/Json.hs
+++ b/src/Waargonaut/Types/Json.hs
@@ -58,7 +58,7 @@ import           Data.Foldable               (Foldable (..), asum)
 import           Data.Function               (flip)
 import           Data.Functor                (Functor (..))
 import           Data.Monoid                 (Monoid (..))
-import           Data.Semigroup              ((<>))
+import           Data.Semigroup              (Semigroup, (<>))
 import           Data.Traversable            (Traversable (..))
 import           Data.Tuple                  (uncurry)
 

--- a/src/Waargonaut/Types/Json.hs
+++ b/src/Waargonaut/Types/Json.hs
@@ -240,11 +240,21 @@ oat k = _JObj . _1 . _MapLikeObj . at k
 
 -- |
 -- A 'Control.Lens.Traversal'' over the 'a' at the given 'Int' position in a JSON object.
+--
+-- >>> E.simplePureEncodeNoSpaces E.json (obj & oix 0 .~ E.runPureEncoder E.int 1)
+-- "{\"a\":1,\"b\":\"Fred\"}"
+-- >>> E.simplePureEncodeNoSpaces E.json (obj & oix 1 .~ E.runPureEncoder E.text "sally")
+-- "{\"a\":33,\"b\":\"sally\"}"
 oix :: (Semigroup ws, Monoid ws, AsJType r ws a) => Int -> Traversal' r a
 oix i = _JObj . _1 . ix i
 
 -- |
 -- A 'Control.Lens.Traversal'' over the 'a' at the given 'Int' position in a JSON array.
+--
+-- >>> E.simplePureEncodeNoSpaces E.json ((E.runPureEncoder (E.list E.int) [1,2,3]) & aix 0 .~ E.runPureEncoder E.int 99)
+-- "[99,2,3]"
+-- >>> E.simplePureEncodeNoSpaces E.json ((E.runPureEncoder (E.list E.int) [1,2,3]) & aix 2 .~ E.runPureEncoder E.int 44)
+-- "[1,2,44]"
 aix :: (AsJType r ws a, Semigroup ws, Monoid ws) => Int -> Traversal' r a
 aix i = _JArr . _1 . ix i
 

--- a/src/Waargonaut/Types/Json.hs
+++ b/src/Waargonaut/Types/Json.hs
@@ -235,17 +235,17 @@ jTypesBuilder s (JObj jobj tws) = jObjectBuilder s waargonautBuilder jobj       
 -- >>> E.simplePureEncodeNoSpaces E.json (obj & oat "d" ?~ E.runPureEncoder E.text "sally")
 -- "{\"d\":\"sally\",\"a\":33,\"b\":\"Fred\"}"
 --
-oat :: (AsJType r ws a, Monoid ws) => Text -> Traversal' r (Maybe a)
+oat :: (AsJType r ws a, Semigroup ws, Monoid ws) => Text -> Traversal' r (Maybe a)
 oat k = _JObj . _1 . _MapLikeObj . at k
 
 -- |
 -- A 'Control.Lens.Traversal'' over the 'a' at the given 'Int' position in a JSON object.
-oix :: (Monoid ws, AsJType r ws a) => Int -> Traversal' r a
+oix :: (Semigroup ws, Monoid ws, AsJType r ws a) => Int -> Traversal' r a
 oix i = _JObj . _1 . ix i
 
 -- |
 -- A 'Control.Lens.Traversal'' over the 'a' at the given 'Int' position in a JSON array.
-aix :: (AsJType r ws a, Monoid ws) => Int -> Traversal' r a
+aix :: (AsJType r ws a, Semigroup ws, Monoid ws) => Int -> Traversal' r a
 aix i = _JArr . _1 . ix i
 
 

--- a/test/Decoder/Laws.hs
+++ b/test/Decoder/Laws.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 module Decoder.Laws (decoderLaws) where
 
-import           Control.Applicative     (Applicative, liftA3, pure)
+import           Control.Applicative     (Applicative, pure)
 import           Control.Monad.Except    (throwError)
 
 import           Data.Functor.Alt        (Alt ((<!>)))
@@ -14,8 +14,6 @@ import           Test.Tasty              (TestTree, testGroup)
 import           Test.Tasty.Hedgehog     (testProperty)
 
 import           Hedgehog
-import           Hedgehog.Function       (Arg, Vary)
-import qualified Hedgehog.Function       as Fn
 import qualified Hedgehog.Gen            as Gen
 
 import qualified Waargonaut.Decode       as D
@@ -24,15 +22,12 @@ import           Waargonaut.Decode.Types (Decoder)
 
 import           Types.Common            (parseBS)
 
+import qualified Laws
+
 runD :: Decoder Identity a -> Either (DecodeError, D.CursorHistory) a
 runD d = D.runPureDecode d parseBS (D.mkCursor "true")
 
-runSD :: ShowDecoder a -> Either (DecodeError, D.CursorHistory) a
-runSD = runD . unShowDecoder
-
-newtype ShowDecoder a = SD
-  { unShowDecoder :: Decoder Identity a
-  }
+newtype ShowDecoder a = SD (Decoder Identity a)
   deriving (Functor, Monad, Applicative)
 
 instance Alt ShowDecoder where
@@ -50,178 +45,30 @@ genShowDecoder genA = Gen.choice
   , SD <$> Gen.constant (throwError $ ConversionFailure "Intentional DecodeError (TEST)")
   ]
 
--- |
--- Alt Associative
--- <!> is associative:             (a <!> b) <!> c = a <!> (b <!> c)
---
-alt_associativity :: Property
-alt_associativity = property $ do
-  (a,b,c) <- forAll $ liftA3 (,,)
-    (genShowDecoder Gen.bool)
-    (genShowDecoder Gen.bool)
-    (genShowDecoder Gen.bool)
-
-  runSD ((a <!> b) <!> c) === runSD (a <!> (b <!> c))
-
--- |
--- Alt left distributes
--- <$> left-distributes over <!>:  f <$> (a <!> b) = (f <$> a) <!> (f <$> b)
-alt_left_distributes
-  :: forall a b.
-     ( Show a, Arg a, Vary a, Eq a
-     , Show b, Arg b, Vary b, Eq b
-     )
-  => Gen a
-  -> Gen b
-  -> Property
-alt_left_distributes genA genB = property $ do
-  f <- Fn.forAllFn $ Fn.fn genA
-
-  a <- forAll (genShowDecoder genB)
-  b <- forAll (genShowDecoder genB)
-
-  runSD ( f <$> (a <!> b) ) === runSD ( (f <$> a) <!> (f <$> b) )
-
--- |
--- identity
---
---     pure id <*> v = v
-applicative_id :: Property
-applicative_id = property $ do
-  a <- forAll (genShowDecoder Gen.bool)
-  runSD (pure id <*> a) === runSD a
-
--- |
--- composition
---
---     pure (.) <*> u <*> v <*> w = u <*> (v <*> w)
-applicative_composition
-  :: forall a b c.
-     ( Show a, Arg a, Vary a, Eq a
-     , Show b, Arg b, Vary b, Eq b
-     , Show c, Arg c, Vary c
-     )
-  => Gen a
-  -> Gen b
-  -> Gen c
-  -> Property
-applicative_composition genA genB genC = property $ do
-  u <- Fn.forAllFn $ Fn.fn genB
-  v <- Fn.forAllFn $ Fn.fn genC
-
-  w <- forAll (genShowDecoder genA)
-
-  let
-    dU = pure u
-    dV = pure v
-
-  runSD ( pure (.) <*> dU <*> dV <*> w ) === runSD ( dU <*> ( dV <*> w ) )
-
--- |
--- homomorphism
---
---     pure f <*> pure x = pure (f x)
-applicative_homomorphism
-  :: forall a b.
-     ( Show a, Arg a, Vary a, Eq a
-     , Show b, Arg b, Vary b
-     )
-  => Gen a
-  -> Gen b
-  -> Property
-applicative_homomorphism genA genB = property $ do
-  f <- Fn.forAllFn $ Fn.fn genA
-  x <- forAll genB
-
-  runD (pure f <*> pure x) === runD (pure (f x))
-
--- |
--- interchange
---
---     u <*> pure y = pure ($ y) <*> u
-applicative_interchange
-  :: forall u y.
-     ( Show u, Arg u, Vary u, Eq u
-     , Show y, Arg y, Vary y
-     )
-  => Gen u
-  -> Gen y
-  -> Property
-applicative_interchange genU genY = property $ do
-  u <- Fn.forAllFn $ Fn.fn genU
-  y <- forAll genY
-
-  let
-    dU = pure u
-
-  runD (dU <*> pure y) === runD (pure ($ y) <*> dU)
-
--- |
--- monad
---
---    return a >>= k = k a
-monad_return_bind
-  :: forall a k.
-     ( Show a, Arg a, Vary a, Eq a
-     , Show k, Arg k, Vary k, Eq k
-     )
-  => Gen a
-  -> Gen k
-  -> Property
-monad_return_bind genA genK = property $ do
-  k' <- Fn.forAllFn $ Fn.fn genK
-  a <- forAll genA
-
-  let
-    k = SD . pure . k'
-
-  runSD (return a >>= k) === runSD (k a)
-
--- |
--- monad
---
---     m >>= return  =  m
-monad_bind_return :: Property
-monad_bind_return = property $ do
-  m <- forAll (genShowDecoder Gen.bool)
-
-  runSD (m >>= return) === runSD m
-
--- |
--- monad
---
---     m >>= (\x -> k x >>= h)  =  (m >>= k) >>= h
-monad_associativity
-  :: forall m k h.
-     ( Show m, Arg m, Vary m, Eq m
-     , Show k, Arg k, Vary k, Eq k
-     , Show h, Arg h, Vary h, Eq h
-     )
-  => Gen m
-  -> Gen k
-  -> Gen h
-  -> Property
-monad_associativity genM genK genH = property $ do
-  m <- forAll (genShowDecoder genM)
-
-  k' <- Fn.forAllFn $ Fn.fn genK
-  h' <- Fn.forAllFn $ Fn.fn genH
-
-  let
-    k = SD . pure . k'
-    h = SD . pure . h'
-
-  runSD (m >>= (\x -> k x >>= h)) === runSD ( (m >>= k) >>= h )
-
 decoderLaws :: TestTree
 decoderLaws = testGroup "Decoder Laws"
-  [ testProperty "Applicative 'identity'" applicative_id
-  , testProperty "Applicative 'composition'" $ applicative_composition Gen.bool Gen.bool Gen.bool
-  , testProperty "Applicative 'homomorphism'" $ applicative_homomorphism Gen.bool Gen.bool
-  , testProperty "Applicative 'interchange'" $ applicative_interchange Gen.bool Gen.bool
-  , testProperty "Alt 'associativity'" alt_associativity
-  , testProperty "Alt 'left distributes'" $ alt_left_distributes Gen.bool Gen.bool
-  , testProperty "Monad 'return a >>= k = k a'" $ monad_return_bind Gen.bool Gen.bool
-  , testProperty "Monad 'm >>= return = m'" monad_bind_return
-  , testProperty "Monad 'associativity'" $ monad_associativity Gen.bool Gen.bool Gen.bool
+  [ testGroup "Applicative"
+
+    [ testProperty "identity"     $ Laws.applicative_id genShowDecoder Gen.bool
+    , testProperty "composition"  $ Laws.applicative_composition genShowDecoder Gen.bool Gen.bool Gen.bool
+    , testProperty "homomorphism" $ Laws.applicative_homomorphism sdPure Gen.bool Gen.bool
+    , testProperty "interchange"  $ Laws.applicative_interchange sdPure Gen.bool Gen.bool
+    ]
+
+  , testGroup "Alt"
+    [ testProperty "associativity"    $ Laws.alt_associativity genShowDecoder Gen.bool
+    , testProperty "left distributes" $ Laws.alt_left_distributes genShowDecoder Gen.bool Gen.bool
+    ]
+
+  , testGroup "Monad"
+    [ testProperty "return a >>= k = k a" $ Laws.monad_return_bind genShowDecoder Gen.bool Gen.bool
+    , testProperty "m >>= return = m"     $ Laws.monad_bind_return_id genShowDecoder Gen.bool
+    , testProperty "associativity"        $ Laws.monad_associativity genShowDecoder Gen.bool Gen.bool Gen.bool
+    ]
+
+  , testGroup "Functor"
+    [ testProperty "'fmap compose'" $ Laws.fmap_compose genShowDecoder Gen.bool Gen.bool Gen.bool
+    ]
   ]
+  where
+    sdPure = (pure :: a -> ShowDecoder a)

--- a/test/Decoder/Laws.hs
+++ b/test/Decoder/Laws.hs
@@ -42,7 +42,7 @@ instance Show a => Show (ShowDecoder a) where
 genShowDecoder :: Gen a -> Gen (ShowDecoder a)
 genShowDecoder genA = Gen.choice
   [ SD . pure <$> genA
-  , SD <$> Gen.constant (throwError $ ConversionFailure "Intentional DecodeError (TEST)")
+  , SD        <$> Gen.constant (throwError $ ConversionFailure "Intentional DecodeError (TEST)")
   ]
 
 decoderLaws :: TestTree

--- a/test/Encoder/Laws.hs
+++ b/test/Encoder/Laws.hs
@@ -2,19 +2,21 @@
 {-# LANGUAGE RankNTypes       #-}
 module Encoder.Laws (encoderLaws) where
 
-import           Test.Tasty            (TestTree, testGroup)
-import           Test.Tasty.Hedgehog   (testProperty)
+import           Test.Tasty                 (TestTree, testGroup)
+import           Test.Tasty.Hedgehog        (testProperty)
 
-import           Data.ByteString.Lazy  (ByteString)
-import           Data.Functor.Identity (Identity)
+import           Data.ByteString.Lazy       (ByteString)
+import           Data.Functor.Contravariant (contramap)
+import           Data.Functor.Identity      (Identity)
 
 import           Hedgehog
-import           Hedgehog.Function     (Arg, Vary)
-import qualified Hedgehog.Function     as Fn
-import qualified Hedgehog.Gen          as Gen
+import qualified Hedgehog.Function          as Fn
+import qualified Hedgehog.Gen               as Gen
 
-import           Waargonaut.Encode     (Encoder)
-import qualified Waargonaut.Encode     as E
+import           Waargonaut.Encode          (Encoder)
+import qualified Waargonaut.Encode          as E
+
+import qualified Laws
 
 runSE :: ShowEncoder a -> a -> ByteString
 runSE (SE e) = E.simplePureEncodeNoSpaces e
@@ -27,39 +29,15 @@ instance Show a => Show (ShowEncoder a) where
 instance Fn.Contravariant ShowEncoder where
   contramap f (SE a) = SE (Fn.contramap f a)
 
--- |
--- contravariant
---
---     contramap f . contramap g = contramap (g . f)
-contravariant_composition
-  :: forall f a.
-     ( Show f, Arg f, Vary f, Eq f
-     , Show a, Arg a, Vary a
-     )
-  => Gen f
-  -> Gen Bool
-  -> Gen a
-  -> Property
-contravariant_composition genF genG genA = property $ do
-  f <- Fn.forAllFn $ Fn.fn genF
-  g <- Fn.forAllFn $ Fn.fn genG
-
-  let ea = SE E.bool
-
-  a <- forAll genA
-
-  runSE (Fn.contramap f $ Fn.contramap g ea) a === runSE (Fn.contramap (g . f) ea) a
-
-contravariant_identity :: Property
-contravariant_identity = property $ do
-  a <- forAll Gen.bool
-
-  let ea = SE E.bool
-
-  runSE (Fn.contramap id ea) a === runSE ea a
+genShowEncoder :: Encoder Identity a -> Gen a -> Gen (ShowEncoder a)
+genShowEncoder enc _ = Gen.constant (SE enc)
 
 encoderLaws :: TestTree
 encoderLaws = testGroup "Encoder Laws"
-  [ testProperty "Contravariant 'composition'" $ contravariant_composition Gen.bool Gen.bool Gen.bool
-  , testProperty "Contravariant 'identity'" contravariant_identity
+  [ testGroup "Contravariant"
+    [ testProperty "composition"
+      $ Laws.contravariant_composition_with_run (genShowEncoder E.bool) runSE Gen.bool (Gen.maybe Gen.bool) Gen.bool
+    , testProperty "identity"
+      $ Laws.contravariant_identity_with_run (genShowEncoder E.bool) runSE Gen.bool
+    ]
   ]

--- a/test/Laws.hs
+++ b/test/Laws.hs
@@ -1,0 +1,254 @@
+{-# LANGUAGE RankNTypes          #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Laws
+  ( fmap_compose
+
+  , alt_left_distributes
+  , alt_associativity
+
+  , applicative_id
+  , applicative_composition
+  , applicative_homomorphism
+  , applicative_interchange
+
+  , monad_return_bind
+  , monad_bind_return_id
+  , monad_associativity
+  ) where
+
+import           Control.Applicative (liftA3)
+
+import           Data.Functor.Alt    (Alt (..))
+
+import           Hedgehog
+import           Hedgehog.Function   (Arg, Vary)
+import qualified Hedgehog.Function   as Fn
+
+fmap_compose
+  :: forall f a b c
+   . ( Functor f
+     , Show (f a)
+     , Show a, Arg a, Vary a
+     , Show b, Arg b, Vary b
+     , Show c
+     , Eq (f c)
+     , Show (f c)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Gen b
+  -> Gen c
+  -> Property
+fmap_compose genF genA genB genC = property $ do
+  g <- Fn.forAllFn $ Fn.fn genB
+  f <- Fn.forAllFn $ Fn.fn genC
+  xs <- forAll $ genF genA
+  fmap (f . g) xs === fmap f (fmap g xs)
+
+-- |
+-- Alt left distributes
+-- <$> left-distributes over <!>:  f <$> (a <!> b) = (f <$> a) <!> (f <$> b)
+alt_left_distributes
+  :: forall a b f.
+     ( Alt f
+     , Show a, Arg a, Vary a, Eq a
+     , Show b, Arg b, Vary b, Eq b
+     , Show (f a), Eq (f a)
+     , Show (f b)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Gen b
+  -> Property
+alt_left_distributes genF genA genB = property $ do
+  f <- Fn.forAllFn $ Fn.fn genA
+
+  a <- forAll (genF genB)
+  b <- forAll (genF genB)
+
+  (f <$> (a <!> b)) === ((f <$> a) <!> (f <$> b))
+
+-- |
+-- Alt Associative
+-- <!> is associative:             (a <!> b) <!> c = a <!> (b <!> c)
+--
+alt_associativity
+  :: forall f a.
+     ( Alt f
+     , Show (f a), Eq (f a)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Property
+alt_associativity genF genA = property $ do
+  (a,b,c) <- forAll $ liftA3 (,,)
+    (genF genA)
+    (genF genA)
+    (genF genA)
+
+  ((a <!> b) <!> c) === (a <!> (b <!> c))
+
+-- |
+-- identity
+--
+--     pure id <*> v = v
+applicative_id
+  :: forall f a.
+     ( Applicative f
+     , Show (f a)
+     , Eq (f a)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Property
+applicative_id genF genA = property $ do
+  a <- forAll (genF genA)
+  (pure id <*> a) === a
+
+-- |
+-- composition
+--
+--     pure (.) <*> u <*> v <*> w = u <*> (v <*> w)
+applicative_composition
+  :: forall f a b c.
+     ( Show a, Arg a, Vary a, Eq a
+     , Show b, Arg b, Vary b, Eq b
+     , Show c, Arg c, Vary c
+     , Show (f a)
+     , Show (f b)
+     , Show (f c)
+     , Eq (f a)
+     , Eq (f b)
+     , Eq (f c)
+     , Applicative f
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Gen b
+  -> Gen c
+  -> Property
+applicative_composition genF genA genB genC = property $ do
+  u <- Fn.forAllFn $ Fn.fn genB
+  v <- Fn.forAllFn $ Fn.fn genC
+
+  w <- forAll (genF genA)
+
+  let
+    dU = pure u
+    dV = pure v
+
+  ( pure (.) <*> dU <*> dV <*> w ) === ( dU <*> ( dV <*> w ) )
+
+-- |
+-- homomorphism
+--
+--     pure f <*> pure x = pure (f x)
+applicative_homomorphism
+  :: forall f a b.
+     ( Show a, Arg a, Vary a, Eq a
+     , Show b, Arg b, Vary b
+     , Show (f a), Eq (f a)
+     , Show (f a), Eq (f b)
+     , Applicative f
+     )
+  => (forall x. x -> f x)
+  -> Gen a
+  -> Gen b
+  -> Property
+applicative_homomorphism pureF genA genB = property $ do
+  f <- Fn.forAllFn $ Fn.fn genA
+  x <- forAll genB
+
+  (pureF f <*> pureF x) === (pureF (f x))
+
+-- |
+-- interchange
+--
+--     u <*> pure y = pure ($ y) <*> u
+applicative_interchange
+  :: forall f u y.
+     ( Applicative f
+     , Show u, Arg u, Vary u, Eq u
+     , Show y, Arg y, Vary y
+     , Show (f u), Eq (f u)
+     , Show (f y), Eq (f y)
+     )
+  => (forall x. x -> f x)
+  -> Gen u
+  -> Gen y
+  -> Property
+applicative_interchange pureF genU genY = property $ do
+  u <- Fn.forAllFn $ Fn.fn genU
+  y <- forAll genY
+
+  let
+    dU = pureF u
+
+  (dU <*> pure y) === (pure ($ y) <*> dU)
+
+-- |
+-- monad
+--
+--    return a >>= k = k a
+monad_return_bind
+  :: forall f a k.
+     ( Monad f
+     , Show a, Arg a, Vary a, Eq a
+     , Show k, Arg k, Vary k, Eq k
+     , Show (f a), Eq (f a)
+     , Show (f k), Eq (f k)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Gen k
+  -> Property
+monad_return_bind genF genA genK = property $ do
+  k <- Fn.forAllFn $ Fn.fn (genF genK)
+  a <- forAll genA
+
+  (return a >>= k) === (k a)
+
+-- |
+-- monad
+--
+--     m >>= return  =  m
+monad_bind_return_id
+  :: forall f a.
+     ( Monad f
+     , Show a, Eq a
+     , Show (f a), Eq (f a)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen a
+  -> Property
+monad_bind_return_id genF genA = property $ do
+  m <- forAll (genF genA)
+
+  (m >>= return) === m
+
+-- |
+-- monad
+--
+--     m >>= (\x -> k x >>= h)  =  (m >>= k) >>= h
+monad_associativity
+  :: forall f m k h.
+     ( Monad f
+     , Show m, Arg m, Vary m, Eq m
+     , Show k, Arg k, Vary k, Eq k
+     , Show h, Arg h, Vary h, Eq h
+     , Show (f m), Eq (f m)
+     , Show (f k), Eq (f k)
+     , Show (f h), Eq (f h)
+     )
+  => (forall x. Gen x -> Gen (f x))
+  -> Gen m
+  -> Gen k
+  -> Gen h
+  -> Property
+monad_associativity genF genM genK genH = property $ do
+  m <- forAll (genF genM)
+
+  k <- Fn.forAllFn $ Fn.fn (genF genK)
+  h <- Fn.forAllFn $ Fn.fn (genF genH)
+
+  (m >>= (\x -> k x >>= h)) === ( (m >>= k) >>= h )

--- a/test/Types/Common.hs
+++ b/test/Types/Common.hs
@@ -31,6 +31,7 @@ module Types.Common
   , Image (..)
   , Fudge (..)
   , HasImage (..)
+  , Overlayed (..)
   ) where
 
 import           Generics.SOP                (Generic, HasDatatypeInfo)
@@ -161,6 +162,13 @@ instance JsonDecode t Fudge where mkDecoder = gDecoder fudgeJsonOpts
 
 testFudge :: Fudge
 testFudge = Fudge "Chocolate"
+
+data Overlayed = Overlayed
+  { _overId :: Text
+  , _overFu :: Fudge
+  }
+  deriving (Show, GHC.Generic)
+
 genDecimalDigit :: Gen DecDigit
 genDecimalDigit = Gen.element decimalDigit
 

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -202,6 +202,7 @@ test-suite waarg-tests
                      , semigroupoids          >= 5.2.2  && < 6
                      , containers             >= 0.5.6  && < 0.7
                      , natural                >= 0.3    && < 4
+                     , contravariant       >= 1.4     && < 2
 
                      , waargonaut
 

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.3.0.0
+version:             0.4.0.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling
@@ -88,6 +88,7 @@ library
                      , Waargonaut.Decode.ZipperMove
                      , Waargonaut.Decode.Error
                      , Waargonaut.Decode.Types
+                     , Waargonaut.Encode.Types
 
                      , Waargonaut.Decode
                      , Waargonaut.Decode.Traversal

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -168,6 +168,7 @@ test-suite waarg-tests
                      , Types.Json
                      , Types.Whitespace
 
+                     , Laws
                      , Utils
                      , Encoder
                      , Encoder.Laws

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.3.0.0";
+  version = "0.4.0.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [
@@ -21,9 +21,9 @@ mkDerivation {
     transformers vector witherable wl-pprint-annotated zippers
   ];
   testHaskellDepends = [
-    attoparsec base bytestring containers digit directory distributive
-    doctest filepath generics-sop hedgehog hedgehog-fn lens mtl natural
-    scientific semigroupoids semigroups tagged tasty
+    attoparsec base bytestring containers contravariant digit directory
+    distributive doctest filepath generics-sop hedgehog hedgehog-fn
+    lens mtl natural scientific semigroupoids semigroups tagged tasty
     tasty-expected-failure tasty-hedgehog tasty-hunit template-haskell
     text vector zippers
   ];


### PR DESCRIPTION
Silly mistakes and some ergonmics improvements for various components of the
encoding and decoding API. Including more tests! :D

There are two new toys in here, both of which need documentation and tests. The `oix` and `oat` functions that let you mess with `JObject` inside of a `Json` structure directly. Without any unwrapping or rewrapping faffery.

**HOW-FREAKING-EVER**, neither of which will enforce key uniqueness. They work with `JObject` which doesn't care for such things. They also currently can't enforce that the bit of `Json` you're pointing them at is actually a `JObject`. So if you try to encode some `Text` and then set the value of the key `"foo"` on that text, you're only going to get the `Text` out... Not some weird text with a key value pair hanging off it.

Suggestions, other API missteps / improvements and related pedantry are encouraged. Trying to keep my hackage churn to a bit of a minimum.