### PR TITLE
Add function to condense cursor history before printing.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # Revision history for waargonaut
 
+## 0.4.2.0  -- 2018-11-23
+
+* Improved pretty printing of CursorHistory by condensing multiple numeric movements and removing the single movements following searching for keys.
+
 ## 0.4.1.0  -- 2018-11-20
 
 * Add `oneOf` decoder and tests

--- a/src/Waargonaut/Decode/Internal.hs
+++ b/src/Waargonaut/Decode/Internal.hs
@@ -61,6 +61,7 @@ import           Control.Monad.Morph           (MFunctor (..), MMonad (..))
 import           Data.Bifunctor                (first)
 import qualified Data.Foldable                 as F
 import           Data.Functor                  (($>))
+import           Data.Semigroup                ((<>))
 import           Data.Sequence                 (Seq, fromList)
 
 import           Data.Text                     (Text)

--- a/src/Waargonaut/Decode/Internal.hs
+++ b/src/Waargonaut/Decode/Internal.hs
@@ -10,6 +10,8 @@
 module Waargonaut.Decode.Internal
   ( CursorHistory' (..)
   , ppCursorHistory
+  , compressHistory
+
   , DecodeResultT (..)
   , Decoder' (..)
 
@@ -47,7 +49,6 @@ import           Control.Applicative           (liftA2, (<|>))
 import           Control.Lens                  (Rewrapped, Wrapped (..), (%=),
                                                 _1, _Wrapped)
 import qualified Control.Lens                  as L
-
 import           Control.Monad                 ((>=>))
 import           Control.Monad.Except          (ExceptT (..), MonadError (..),
                                                 liftEither, runExceptT)
@@ -58,8 +59,9 @@ import           Control.Monad.Error.Hoist     ((<!?>))
 import           Control.Monad.Morph           (MFunctor (..), MMonad (..))
 
 import           Data.Bifunctor                (first)
+import qualified Data.Foldable                 as F
 import           Data.Functor                  (($>))
-import           Data.Sequence                 (Seq)
+import           Data.Sequence                 (Seq, fromList)
 
 import           Data.Text                     (Text)
 
@@ -72,6 +74,8 @@ import qualified Data.Witherable               as Wither
 
 import           Data.Scientific               (Scientific)
 import qualified Data.Scientific               as Sci
+
+import           Natural                       (Natural, _Natural)
 
 import           Waargonaut.Types              (AsJType (..), JString,
                                                 jNumberToScientific,
@@ -96,6 +100,53 @@ newtype CursorHistory' i = CursorHistory'
   }
   deriving (Show, Eq)
 
+switchbackMoves
+  :: (Natural -> a)
+  -> (Natural -> a)
+  -> Natural
+  -> Natural
+  -> b
+  -> b
+  -> [(a, b)]
+  -> [(a, b)]
+switchbackMoves a b n m i i' sq =
+  let
+    n' = _Natural L.# n :: Int
+    m' = _Natural L.# m
+  in
+    if n' > m'
+    then (a $ (n' - m') L.^. _Natural, i)  : sq
+    else (b $ (m' - n') L.^. _Natural, i') : sq
+
+rmKeyJumps :: [(ZipperMove, i)] -> [(ZipperMove, i)]
+rmKeyJumps (d@(DAt _, _) : (R _, _) : sq) = d:sq
+rmKeyJumps s                              = s
+
+combineLRMoves :: [(ZipperMove, i)] -> [(ZipperMove, i)]
+combineLRMoves ((R n, _) : (R m, i)  : sq) = (R (n <> m), i) : sq
+combineLRMoves ((L n, _) : (L m, i)  : sq) = (L (n <> m), i) : sq
+combineLRMoves ((L n, i) : (R m, i') : sq) = switchbackMoves L R n m i i' sq
+combineLRMoves ((R n, i) : (L m, i') : sq) = switchbackMoves R L n m i i' sq
+combineLRMoves s                           = s
+
+-- | This function will condense incidental movements, reducing the amount of
+-- noise in the error output.
+--
+-- The rules that are currently applied are:
+--
+-- * [R n, R m]   = [R (n + m)]
+-- * [L n, R m]   = [L (n + m)]
+-- * [R n, L m]   = [R (n - m)] where n > m
+-- * [R n, L m]   = [L (m - n)] where n < m
+-- * [L n, R m]   = [L (n - m)] where n > m
+-- * [L n, R m]   = [R (m - n)] where n < m
+-- * [DAt k, R n] = [DAt k]
+--
+-- This function is automatically applied when using the 'ppCursorHistory'
+-- function to render the cursor movements.
+compressHistory :: CursorHistory' i -> CursorHistory' i
+compressHistory = L.over _Wrapped (fromList . L.transform (combineLRMoves . rmKeyJumps) . F.toList)
+
 -- |
 -- Pretty print the given 'CursorHistory'' to a more useful format compared to a 'Seq' of 'i'.
 ppCursorHistory
@@ -105,6 +156,7 @@ ppCursorHistory =
   foldr (<+>) mempty
   . fmap (ppZipperMove . fst)
   . unCursorHistory'
+  . compressHistory
 
 instance CursorHistory' i ~ t => Rewrapped (CursorHistory' i) t
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TupleSections     #-}
 module Main (main) where
 
 import           Control.Lens                (( # ), (^.), (^?), _2)
 import qualified Control.Lens                as L
+import           Control.Monad               (when)
 
 import           Data.Either                 (isLeft)
 
@@ -18,6 +20,8 @@ import           Data.Semigroup              ((<>))
 import           Data.Text                   (Text)
 import qualified Data.Text.Encoding          as Text
 
+import qualified Data.Sequence               as S
+
 import           Hedgehog
 import qualified Hedgehog.Gen                as Gen
 import qualified Hedgehog.Range              as Range
@@ -25,6 +29,8 @@ import qualified Hedgehog.Range              as Range
 import           Test.Tasty
 import           Test.Tasty.Hedgehog
 import           Test.Tasty.HUnit
+
+import           Natural                     (_Natural)
 
 import           Data.Digit                  (HeXDigit)
 
@@ -40,6 +46,8 @@ import qualified Waargonaut.Types.Whitespace as WS
 
 import qualified Waargonaut.Decode           as D
 import           Waargonaut.Decode.Error     (DecodeError)
+import           Waargonaut.Decode.Internal  (CursorHistory' (..),
+                                              ZipperMove (..), compressHistory)
 import qualified Waargonaut.Encode           as E
 
 import           Waargonaut.Generic          (mkDecoder, mkEncoder)
@@ -74,6 +82,39 @@ decode
   -> Either DecodeError Json
 decode =
   Common.parseText
+
+prop_history_condense :: Property
+prop_history_condense = property $ do
+  n <- forAll $ Gen.int (Range.linear 1 10)
+  m <- forAll $ Gen.int (Range.linear 1 10)
+
+  let
+    ixa = 1 :: Int
+    ixb = 2
+    mkCH = CursorHistory' . S.fromList
+    mcA cn cm n' m' = mkCH [(cn (n' ^. _Natural), ixa), (cm (m' ^. _Natural), ixb)]
+    mcB c x i = mkCH [(c (x ^. _Natural), i)]
+
+  -- * [R n, R m]   = [R (n + m)]
+  compressHistory (mcA R R n m) === mcB R (n + m) ixb
+
+  -- * [L n, R m]   = [L (n + m)]
+  compressHistory (mcA L L n m) === mcB L (n + m) ixb
+
+  when (n > m) $ do
+    -- * [R n, L m]   = [R (n - m)] where n > m
+    compressHistory (mcA R L n m) === mcB R (n - m) ixa
+    -- * [L n, R m]   = [L (n - m)] where n > m
+    compressHistory (mcA L R n m) === mcB L (n - m) ixa
+
+  when (n < m) $ do
+    -- * [R n, L m]   = [L (m - n)] where n < m
+    compressHistory (mcA R L n m) === mcB L (m - n) ixb
+    -- * [L n, R m]   = [R (m - n)] where n < m
+    compressHistory (mcA L R n m) === mcB R (m - n) ixb
+
+  -- * [DAt k, R n] = [DAt k]
+  compressHistory (mkCH [(DAt "KeyName", ixa), (R (n ^. _Natural), ixb)]) === mkCH [(DAt "KeyName", ixa)]
 
 prop_uncons_consCommaSep :: Property
 prop_uncons_consCommaSep = property $ do
@@ -177,7 +218,7 @@ prop_maybe_maybe = withTests 1 . property $ do
       -- $ D.atKey "beep" (D.maybeOrNull D.bool)
 
 tripping_properties :: TestTree
-tripping_properties = testGroup "Round Trip"
+tripping_properties = testGroup "Properties"
   [ testProperty "CommaSeparated: cons . uncons = id"                  prop_uncons_consCommaSep
   , testProperty "CommaSeparated (disregard WS): cons . uncons = id"   prop_uncons_consCommaSepVal
   , testProperty "Char -> JChar Digit -> Maybe Char = Just id"         prop_jchar
@@ -188,6 +229,7 @@ tripping_properties = testGroup "Round Trip"
   , testProperty "Maybe Bool (generic)"                                prop_tripping_maybe_bool_generic
   , testProperty "Image record (generic)"                              prop_tripping_image_record_generic
   , testProperty "Newtype with Options (generic)"                      prop_tripping_newtype_fudge_generic
+  , testProperty "Condensing History"                                  prop_history_condense
   ]
 
 parser_properties :: TestTree

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -101,17 +101,20 @@ prop_history_condense = property $ do
   -- * [L n, R m]   = [L (n + m)]
   compressHistory (mcA L L n m) === mcB L (n + m) ixb
 
+  let
+    rlch = compressHistory (mcA R L n m)
+    lrch = compressHistory (mcA L R n m)
   when (n > m) $ do
     -- * [R n, L m]   = [R (n - m)] where n > m
-    compressHistory (mcA R L n m) === mcB R (n - m) ixa
+    rlch === mcB R (n - m) ixa
     -- * [L n, R m]   = [L (n - m)] where n > m
-    compressHistory (mcA L R n m) === mcB L (n - m) ixa
+    lrch === mcB L (n - m) ixa
 
   when (n < m) $ do
     -- * [R n, L m]   = [L (m - n)] where n < m
-    compressHistory (mcA R L n m) === mcB L (m - n) ixb
+    rlch === mcB L (m - n) ixb
     -- * [L n, R m]   = [R (m - n)] where n < m
-    compressHistory (mcA L R n m) === mcB R (m - n) ixb
+    lrch === mcB R (m - n) ixb
 
   -- * [DAt k, R n] = [DAt k]
   compressHistory (mkCH [(DAt "KeyName", ixa), (R (n ^. _Natural), ixb)]) === mkCH [(DAt "KeyName", ixa)]

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.4.1.0
+version:             0.4.2.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling


### PR DESCRIPTION
Printing the cursor history can be very noisy as it records EVERY movement which may be counterproductive to being able to locate the actual problem. This adds a function to combine certain combinations of movements down to simpler forms or removes them entirely when they serve no purpose. This leads to much nicer and more digestible messages.

If you want the full history then all the information is still there, but the `ppCursorHistory` function automatically applies this function.