### PR TITLE
Tighten version bounds

### DIFF
--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -103,8 +103,8 @@ library
 
   -- Other library packages from which modules are imported.
   build-depends:       base                >= 4.7     && < 4.13
-                     , lens                >= 4.15    && < 5
-                     , mtl                 >= 2.2.2   && < 3
+                     , lens                >= 4.15    && < 4.18
+                     , mtl                 >= 2.2.2   && < 2.3
                      , text                >= 1.2     && < 1.3
                      , bytestring          >= 0.10.6  && < 0.11
                      , parsers             >= 0.12    && < 0.13
@@ -115,15 +115,15 @@ library
                      , nats                >= 1       && <1.2
                      , zippers             >= 0.2     && < 0.3
                      , vector              >= 0.12    && < 0.13
-                     , errors              >= 2.2     && < 3
+                     , errors              >= 2.2     && < 2.4
                      , hoist-error         >= 0.2     && < 0.3
                      , containers          >= 0.5.6   && < 0.7
                      , witherable          >= 0.2     && < 0.3
                      , generics-sop        >= 0.3.2   && < 0.4
-                     , mmorph              >= 1.1     && < 2
+                     , mmorph              >= 1.1     && < 1.2
                      , transformers        >= 0.4     && < 0.6
-                     , bifunctors          >= 5       && < 6
-                     , contravariant       >= 1.4     && < 2
+                     , bifunctors          >= 5       && < 5.6
+                     , contravariant       >= 1.4     && < 1.6
                      , wl-pprint-annotated >= 0.1     && < 0.2
                      , hw-json             >= 0.9.0.1 && < 0.10
                      , hw-prim             >= 0.6     && < 0.7
@@ -131,8 +131,8 @@ library
                      , hw-rankselect       >= 0.10    && < 0.13
                      , hw-bits             >= 0.7     && < 0.8
                      , tagged              >= 0.8.6   && < 0.9
-                     , semigroupoids       >= 5.2.2   && < 6
-                     , natural             >= 0.3     && < 4
+                     , semigroupoids       >= 5.2.2   && < 5.4
+                     , natural             >= 0.3     && < 0.4
 
   -- Directories containing source files.
   hs-source-dirs:      src
@@ -180,13 +180,13 @@ test-suite waarg-tests
   hs-source-dirs:      test
 
   build-depends:       base                   >= 4.7    && < 4.13
-                     , tasty                  >= 0.11   && < 2
+                     , tasty                  >= 0.11   && < 1.2
                      , tasty-hunit            >= 0.10   && < 0.11
                      , tasty-expected-failure >= 0.11   && < 0.12
                      , hedgehog               >= 0.6    && < 0.7
                      , hedgehog-fn            >= 0.6    && < 0.7
                      , tasty-hedgehog         >= 0.2    && < 0.3
-                     , lens                   >= 4.15   && < 5
+                     , lens                   >= 4.15   && < 4.18
                      , distributive           >= 0.5    && < 0.7
                      , bytestring             >= 0.10.6 && < 0.11
                      , digit                  >= 0.7    && < 0.8
@@ -198,11 +198,11 @@ test-suite waarg-tests
                      , attoparsec             >= 0.13   && < 0.15
                      , scientific             >= 0.3    && < 0.4
                      , tagged                 >= 0.8.6  && < 0.9
-                     , mtl                    >= 2.2.2  && < 3
-                     , semigroupoids          >= 5.2.2  && < 6
+                     , mtl                    >= 2.2.2  && < 2.3
+                     , semigroupoids          >= 5.2.2  && < 5.6
                      , containers             >= 0.5.6  && < 0.7
-                     , natural                >= 0.3    && < 4
-                     , contravariant       >= 1.4     && < 2
+                     , natural                >= 0.3    && < 0.4
+                     , contravariant          >= 1.4    && < 1.6
 
                      , waargonaut
 

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -118,7 +118,7 @@ library
                      , errors              >= 2.2     && < 2.4
                      , hoist-error         >= 0.2     && < 0.3
                      , containers          >= 0.5.6   && < 0.7
-                     , witherable          >= 0.2     && < 0.3
+                     , witherable          >= 0.2     && < 0.4
                      , generics-sop        >= 0.3.2   && < 0.4
                      , mmorph              >= 1.1     && < 1.2
                      , transformers        >= 0.4     && < 0.6


### PR DESCRIPTION
Double-digit major version bounds will help prevent breakage in the future. They mean we need to bump bounds a bit more frequently, but I'll be around to help with that :)