### PR TITLE
Check types before decoding

### DIFF
--- a/src/Waargonaut/Decode/Error.hs
+++ b/src/Waargonaut/Decode/Error.hs
@@ -11,6 +11,8 @@ import qualified Control.Lens                 as L
 
 import           GHC.Word                     (Word64)
 
+import           HaskellWorks.Data.Json.Type  (JsonType)
+
 import           Data.Text                    (Text)
 
 import           Waargonaut.Decode.ZipperMove (ZipperMove)
@@ -29,6 +31,7 @@ data Err c e
 --
 data DecodeError
   = ConversionFailure Text
+  | TypeMismatch JsonType
   | KeyDecodeFailed
   | KeyNotFound Text
   | FailedToMove ZipperMove
@@ -41,6 +44,7 @@ data DecodeError
 class AsDecodeError r where
   _DecodeError       :: Prism' r DecodeError
   _ConversionFailure :: Prism' r Text
+  _TypeMismatch      :: Prism' r JsonType
   _KeyDecodeFailed   :: Prism' r ()
   _KeyNotFound       :: Prism' r Text
   _FailedToMove      :: Prism' r ZipperMove
@@ -49,6 +53,7 @@ class AsDecodeError r where
   _ParseFailed       :: Prism' r Text
 
   _ConversionFailure = _DecodeError . _ConversionFailure
+  _TypeMismatch      = _DecodeError . _TypeMismatch
   _KeyDecodeFailed   = _DecodeError . _KeyDecodeFailed
   _KeyNotFound       = _DecodeError . _KeyNotFound
   _FailedToMove      = _DecodeError . _FailedToMove
@@ -64,6 +69,13 @@ instance AsDecodeError DecodeError where
         (\x -> case x of
             ConversionFailure y -> Right y
             _                   -> Left x
+        )
+
+  _TypeMismatch
+    = L.prism TypeMismatch
+        (\x -> case x of
+            TypeMismatch y -> Right y
+            _              -> Left x
         )
 
   _KeyDecodeFailed

--- a/src/Waargonaut/Decode/Types.hs
+++ b/src/Waargonaut/Decode/Types.hs
@@ -14,6 +14,8 @@ module Waargonaut.Decode.Types
   , Decoder (..)
   , DecodeResult (..)
   , JCurs (..)
+  , jsonTypeAt
+  , JsonType(..)
   ) where
 
 import           Control.Lens                          (Rewrapped, Wrapped (..),
@@ -36,6 +38,7 @@ import           Data.Vector.Storable                  (Vector)
 
 import           HaskellWorks.Data.BalancedParens      (SimpleBalancedParens)
 import           HaskellWorks.Data.Json.Cursor         (JsonCursor (..))
+import           HaskellWorks.Data.Json.Type           (JsonType (..), JsonTypeAt (..))
 import           HaskellWorks.Data.Positioning         (Count)
 import           HaskellWorks.Data.RankSelect.Poppy512 (Poppy512)
 
@@ -95,7 +98,7 @@ instance MFunctor Decoder where
 -- | Wrapper type for the 'SuccinctCursor'
 newtype JCurs = JCurs
   { unJCurs :: SuccinctCursor
-  }
+  } deriving JsonTypeAt
 
 instance JCurs ~ t => Rewrapped JCurs t
 

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -74,9 +74,9 @@ nonEmptyDecoder = do
   assertBool "NonEmpty Decoder - fail! non-empty list decoder BROKEN. Start panicking" (Either.isRight (dec ok))
   assertBool "NonEmpty Decoder - empty list shouldn't succeed" (Either.isLeft (dec notOkay))
   assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badElem))
-  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeObj))
-  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeText))
-  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeNum))
+  assertBool "NonEmpty Decoder - invalid type accepted - object" (Either.isLeft (dec badTypeObj))
+  assertBool "NonEmpty Decoder - invalid type accepted - text" (Either.isLeft (dec badTypeText))
+  assertBool "NonEmpty Decoder - invalid type accepted - num" (Either.isLeft (dec badTypeNum))
 
 listDecoder :: Assertion
 listDecoder = do

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -53,7 +53,7 @@ decoderTests = testGroup "Decoding"
   , testCase "Using Alt (Error) - Records BranchFail" decodeAltError
   , testCase "List Decoder" listDecoder
   , testCase "NonEmpty List Decoder" nonEmptyDecoder
-  , testCase "Object Decoder" objectDecoder
+  , testCase "Object Decoder" objectAsKeyValuesDecoder
   , testCase "Absent Key Decoder" absentKeyDecoder
   ]
 
@@ -98,10 +98,10 @@ listDecoder = do
   assertBool "List Decoder - invalid type accepted - num" (Either.isLeft (dec badTypeNum))
   assertBool "List Decoder - invalid element decoder accepted" (Either.isLeft (dec badElem))
 
-objectDecoder :: Assertion
-objectDecoder = do
+objectAsKeyValuesDecoder :: Assertion
+objectAsKeyValuesDecoder = do
   let
-    dec = D.runPureDecode (D.object D.text D.int) parseBS . D.mkCursor
+    dec = D.runPureDecode (D.objectAsKeyValues D.text D.int) parseBS . D.mkCursor
 
     ok = "{\"1\":1,\"2\":2,\"3\":3}"
     okE = "{}"

--- a/test/Decoder.hs
+++ b/test/Decoder.hs
@@ -53,6 +53,7 @@ decoderTests = testGroup "Decoding"
   , testCase "Using Alt (Error) - Records BranchFail" decodeAltError
   , testCase "List Decoder" listDecoder
   , testCase "NonEmpty List Decoder" nonEmptyDecoder
+  , testCase "Object Decoder" objectDecoder
   , testCase "Absent Key Decoder" absentKeyDecoder
   ]
 
@@ -64,11 +65,18 @@ nonEmptyDecoder = do
     ok = "[1]"
     notOkay = "[]"
 
+    badTypeObj = "{}"
+    badTypeText = "\"test\""
+    badTypeNum = "3"
+
     badElem = "[1, \"fred\"]"
 
   assertBool "NonEmpty Decoder - fail! non-empty list decoder BROKEN. Start panicking" (Either.isRight (dec ok))
   assertBool "NonEmpty Decoder - empty list shouldn't succeed" (Either.isLeft (dec notOkay))
   assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badElem))
+  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeObj))
+  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeText))
+  assertBool "NonEmpty Decoder - invalid element decoder accepted" (Either.isLeft (dec badTypeNum))
 
 listDecoder :: Assertion
 listDecoder = do
@@ -78,13 +86,39 @@ listDecoder = do
     ok = "[1,2,3]"
     okE = "[]"
 
-    badShape = "{}"
+    badTypeObj = "{}"
+    badTypeText = "\"test\""
+    badTypeNum = "3"
     badElem = "[\"fred\", \"susan\"]"
 
   assertBool "List Decoder - fail! List Decoder BROKEN. Start panicking." (Either.isRight (dec ok))
   assertBool "List Decoder - empty list fail" (Either.isRight (dec okE))
-  assertBool "List Decoder - move down should return empty list" (Either.isRight (dec badShape))
+  assertBool "List Decoder - invalid type accepted - object" (Either.isLeft (dec badTypeObj))
+  assertBool "List Decoder - invalid type accepted - text" (Either.isLeft (dec badTypeText))
+  assertBool "List Decoder - invalid type accepted - num" (Either.isLeft (dec badTypeNum))
   assertBool "List Decoder - invalid element decoder accepted" (Either.isLeft (dec badElem))
+
+objectDecoder :: Assertion
+objectDecoder = do
+  let
+    dec = D.runPureDecode (D.object D.text D.int) parseBS . D.mkCursor
+
+    ok = "{\"1\":1,\"2\":2,\"3\":3}"
+    okE = "{}"
+
+    badTypeArray = "[]"
+    badTypeText = "\"test\""
+    badTypeNum = "3"
+    badKey = "{1:1}"
+    badValue = "{\"1\":\"fred\", \"2\":\"susan\"}"
+
+  assertBool "Object Decoder - fail! Object Decoder BROKEN. Start panicking." (Either.isRight (dec ok))
+  assertBool "Object Decoder - empty list fail" (Either.isRight (dec okE))
+  assertBool "Object Decoder - invalid type accepted - object" (Either.isLeft (dec badTypeArray))
+  assertBool "Object Decoder - invalid type accepted - text" (Either.isLeft (dec badTypeText))
+  assertBool "Object Decoder - invalid type accepted - num" (Either.isLeft (dec badTypeNum))
+  assertBool "Object Decoder - invalid key decoder accepted" (Either.isLeft (dec badKey))
+  assertBool "Object Decoder - invalid value decoder accepted" (Either.isLeft (dec badValue))
 
 decodeTestMissingObjKey :: Assertion
 decodeTestMissingObjKey = do


### PR DESCRIPTION
* Add object decoder

This directly re-exports the `JsonType` and the `jsonTypeAt` function from `hw-json`.