### PR TITLE
New release - Expose new functionality, tighten some more screws

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,11 @@
 # Revision history for waargonaut
 
+## 0.5.1.0  -- 2019-01-02
+
+* Fix order of `either` decoder to match documentation, `Right` decoder was not being attempted first.
+* Expose functionality to check the 'type' of the JSON at the current cursor position.
+* Update list decoder to check that we're at an array before attempting to decode. It will now fail when attempting to decode a list and something of type list is not found. Previously it would return an empty list when a number was present.
+
 ## 0.5.0.0  -- 2018-12-18
 
 * Changed internal builder from `ByteString` to `Text` builder.

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.5.0.0
+version:             0.5.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.5.0.0";
+  version = "0.5.1.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
Fix the order that the `Decoder.either` function will attempt the given
decoders, previously it would try the `Left` decoder first. Fixes #43 

List, NonEmpty, and 'objectAsKeyValues' decoders now require that they are
positioned at an array or object before attempting to decode. This means that
the list decoder will now only return an empty list when it is looking at an
empty list.