### PR TITLE
Use nix overlays

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Revision history for waargonaut
 
+## 0.5.2.1  -- 2019-01-08
+
+* Upgraded the nix overrides to use the overlay technique.
+* Lowered the bound on tagged to 0.8.5 which allowed it to be removed from the list of overridden packages.
+
 ## 0.5.1.0  -- 2019-01-02
 
 * Fix order of `either` decoder to match documentation, `Right` decoder was not being attempted first.

--- a/default.nix
+++ b/default.nix
@@ -1,23 +1,15 @@
-{ nixpkgs ? import <nixpkgs> {}
+{ nixpkgsPath ? <nixpkgs>
 , compiler ? "default"
 }:
 let
-  # Can't use overlays as there is a infinite recursion in the list of
-  # dependencies that needs to be fixed first.
-  inherit (nixpkgs) pkgs;
+  pkgs = import nixpkgsPath {
+    overlays = [ (import ./waargonaut-deps.nix) ];
+  };
 
   haskellPackages = if compiler == "default"
     then pkgs.haskellPackages
     else pkgs.haskell.packages.${compiler};
 
-  waarg = import ./waargonaut-deps.nix;
-
-  modifiedHaskellPackages = haskellPackages.override (old: {
-    overrides = pkgs.lib.composeExtensions
-      (old.overrides or (_: _: {}))
-      (waarg pkgs);
-  });
-
-  drv = modifiedHaskellPackages.callPackage ./waargonaut.nix {};
+  drv = haskellPackages.callPackage ./waargonaut.nix {};
 in
   drv

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ nixpkgs ? import <nixpkgs> {}
+{ nixpkgsPath ? <nixpkgs>
 , compiler ? "default"
 }:
-(import ./default.nix { inherit nixpkgs compiler; }).env
+(import ./default.nix { inherit nixpkgsPath compiler; }).env

--- a/waargonaut-deps.nix
+++ b/waargonaut-deps.nix
@@ -1,31 +1,25 @@
-pkgs: (self: super:
+self: super:
 let
   sources = {
     digit          = import ./nix/digit.nix;
     hoist-error    = import ./nix/hoist-error.nix;
     hedgehog       = import ./nix/hedgehog.nix;
-    tasty          = import ./nix/tasty.nix;
     tasty-hedgehog = import ./nix/tasty-hedgehog.nix;
     hedgehog-fn    = import ./nix/hedgehog-fn.nix;
     hw-json        = import ./nix/hw-json.nix;
   };
 in
 {
-  digit          = self.callCabal2nix "digit" sources.digit {};
-
-  hoist-error    = self.callCabal2nix "hoist-error" sources.hoist-error {};
-  tasty-hedgehog = self.callCabal2nix "tasty-hedgehog" sources.tasty-hedgehog {};
-  hedgehog-fn    = self.callCabal2nix "hedgehog-fn" sources.hedgehog-fn {};
-
-  hedgehog       = self.callCabal2nix "hedgehog" "${sources.hedgehog}/hedgehog" {};
-  tasty-hunit    = self.callCabal2nix "tasty-hunit" "${sources.tasty}/hunit" {};
-
-  generics-sop   = self.callHackage "generics-sop" "0.3.2.0" {};
-
-  generic-lens   = pkgs.haskell.lib.dontCheck super.generic-lens;
-
-  tagged         = self.callHackage "tagged" "0.8.6" {};
-
-  hw-parser      = self.callHackage "hw-parser" "0.1.0.0" {};
-  hw-json        = self.callCabal2nix "hw-json" sources.hw-json {};
-})
+  haskellPackages = super.haskellPackages.override (old: {
+    overrides = self.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
+      digit           = hself.callCabal2nix "digit"          sources.digit                  {};
+      hoist-error     = hself.callCabal2nix "hoist-error"    sources.hoist-error            {};
+      tasty-hedgehog  = hself.callCabal2nix "tasty-hedgehog" sources.tasty-hedgehog         {};
+      hedgehog-fn     = hself.callCabal2nix "hedgehog-fn"    sources.hedgehog-fn            {};
+      hedgehog        = hself.callCabal2nix "hedgehog"       "${sources.hedgehog}/hedgehog" {};
+      generics-sop    = hself.callHackage   "generics-sop"   "0.3.2.0"                      {};
+      hw-parser       = hself.callHackage   "hw-parser"      "0.1.0.0"                      {};
+      hw-json         = hself.callCabal2nix "hw-json"        sources.hw-json                {};
+    });
+  });
+}

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -130,8 +130,9 @@ library
                      , hw-prim             >= 0.6     && < 0.7
                      , hw-balancedparens   >= 0.2     && < 0.3
                      , hw-rankselect       >= 0.10    && < 0.13
+                     , hw-rankselect-base
                      , hw-bits             >= 0.7     && < 0.8
-                     , tagged              >= 0.8.6   && < 0.9
+                     , tagged              >= 0.8.5   && < 0.9
                      , semigroupoids       >= 5.2.2   && < 5.4
                      , natural             >= 0.3     && < 0.4
 
@@ -198,7 +199,7 @@ test-suite waarg-tests
                      , generics-sop           >= 0.3.2  && < 0.4
                      , attoparsec             >= 0.13   && < 0.15
                      , scientific             >= 0.3    && < 0.4
-                     , tagged                 >= 0.8.6  && < 0.9
+                     , tagged                 >= 0.8.5  && < 0.9
                      , mtl                    >= 2.2.2  && < 2.3
                      , semigroupoids          >= 5.2.2  && < 5.6
                      , containers             >= 0.5.6  && < 0.7

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -130,7 +130,6 @@ library
                      , hw-prim             >= 0.6     && < 0.7
                      , hw-balancedparens   >= 0.2     && < 0.3
                      , hw-rankselect       >= 0.10    && < 0.13
-                     , hw-rankselect-base
                      , hw-bits             >= 0.7     && < 0.8
                      , tagged              >= 0.8.5   && < 0.9
                      , semigroupoids       >= 5.2.2   && < 5.4

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.5.1.0
+version:             0.5.2.1
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.5.1.0";
+  version = "0.5.2.1";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
The `waargonaut-deps.nix` file is now a proper Nix `overlay`.  Some packages have been removed from the dependency list as they were triggering an infinite recursion issue and their explicit inclusion in the overrides does not appear to be required anymore.

This required the lower bounds on `tagged` to be lowered from `0.8.6` to `0.8.5`. All tests still pass, yey.
