### PR TITLE
Bump generics-sop to v4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ matrix:
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
-    # - compiler: "ghc-7.10.3"
-    # # env: TEST=--disable-tests BENCH=--disable-benchmarks
-    #   addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,9 @@ matrix:
     - compiler: "ghc-8.0.2"
     # env: TEST=--disable-tests BENCH=--disable-benchmarks
       addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-8.0.2], sources: [hvr-ghc]}}
-    - compiler: "ghc-7.10.3"
-    # env: TEST=--disable-tests BENCH=--disable-benchmarks
-      addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
+    # - compiler: "ghc-7.10.3"
+    # # env: TEST=--disable-tests BENCH=--disable-benchmarks
+    #   addons: {apt: {packages: [ghc-ppa-tools,cabal-install-2.4,ghc-7.10.3], sources: [hvr-ghc]}}
 
 before_install:
   - HC=${CC}

--- a/waargonaut-deps.nix
+++ b/waargonaut-deps.nix
@@ -3,6 +3,8 @@ self: super: {
     overrides = self.lib.composeExtensions (old.overrides or (_: _: {})) (hself: hsuper: {
       hw-json   = self.haskell.lib.dontBenchmark (hself.callHackage "hw-json" "0.9.0.1" {});
       hw-parser = hself.callHackage "hw-parser" "0.1.0.0" {};
+      sop-core = hself.callHackage "sop-core" "0.4.0.0" {};
+      generics-sop = hself.callHackage "generics-sop" "0.4.0.1" {};
     });
   });
 }

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -57,8 +57,7 @@ bug-reports:         https://github.com/qfpl/waargonaut/issues
 -- Constraint on the version of Cabal needed to build this package.
 cabal-version:       >=1.10
 
-tested-with:         GHC==7.10.3
-                   , GHC==8.0.2
+tested-with:         GHC==8.0.2
                    , GHC==8.2.2
                    , GHC==8.4.4
                    , GHC==8.6.2
@@ -121,7 +120,7 @@ library
                      , hoist-error         >= 0.2     && < 0.3
                      , containers          >= 0.5.6   && < 0.7
                      , witherable          >= 0.2     && < 0.4
-                     , generics-sop        >= 0.3.2   && < 0.4
+                     , generics-sop        >= 0.4     && < 0.5
                      , mmorph              >= 1.1     && < 1.2
                      , transformers        >= 0.4     && < 0.6
                      , bifunctors          >= 5       && < 5.6
@@ -198,7 +197,7 @@ test-suite waarg-tests
                      , semigroups             >= 0.8.4  && < 0.19
                      , zippers                >= 0.2    && < 0.3
                      , vector                 >= 0.12   && < 0.13
-                     , generics-sop           >= 0.3.2  && < 0.4
+                     , generics-sop           >= 0.4    && < 0.5
                      , attoparsec             >= 0.13   && < 0.15
                      , scientific             >= 0.3    && < 0.4
                      , tagged                 >= 0.8.5  && < 0.9

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.5.2.1
+version:             0.5.2.2
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling
@@ -63,7 +63,7 @@ tested-with:         GHC==8.0.2
                    , GHC==8.6.2
 
 custom-setup
-  setup-depends:       base >= 4 && <5
+  setup-depends:       base >= 4.9 && <5
                      , cabal-doctest >= 1 && <1.1
                      , Cabal
 
@@ -103,7 +103,7 @@ library
   ghc-options:         -Wall
 
   -- Other library packages from which modules are imported.
-  build-depends:       base                >= 4.7     && < 4.13
+  build-depends:       base                >= 4.9     && < 4.13
                      , lens                >= 4.15    && < 4.18
                      , mtl                 >= 2.2.2   && < 2.3
                      , text                >= 1.2     && < 1.3
@@ -147,7 +147,7 @@ test-suite doctests
   default-language:    Haskell2010
   hs-source-dirs:      test
 
-  build-depends:       base             >= 4.7  && < 4.13
+  build-depends:       base             >= 4.9  && < 4.13
                      , hedgehog         >= 0.6  && < 0.7
                      , text             >= 1.2  && < 1.3
                      , digit            >= 0.7  && < 0.8
@@ -182,7 +182,7 @@ test-suite waarg-tests
   main-is:             Main.hs
   hs-source-dirs:      test
 
-  build-depends:       base                   >= 4.7    && < 4.13
+  build-depends:       base                   >= 4.9    && < 4.13
                      , tasty                  >= 0.11   && < 1.3
                      , tasty-hunit            >= 0.10   && < 0.11
                      , tasty-expected-failure >= 0.11   && < 0.12

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.5.2.1";
+  version = "0.5.2.2";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
Fixes #52 

*However* : Waargonaut will no longer build with GHC 7.10.3.
