### PR TITLE
Add Instances, Fix some docs

### DIFF
--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -349,6 +349,8 @@ class JsonEncode t a where
   mkEncoder =
     gEncoder defaultOpts
 
+
+
 instance JsonEncode t a                   => JsonEncode t (Maybe a)    where mkEncoder = E.maybeOrNull <$> mkEncoder
 instance (JsonEncode t a, JsonEncode t b) => JsonEncode t (Either a b) where mkEncoder = E.either <$> mkEncoder <*> mkEncoder
 instance (JsonEncode t a)                 => JsonEncode t [a]          where mkEncoder = E.list <$> mkEncoder
@@ -357,6 +359,7 @@ instance JsonEncode t Text                                             where mkE
 instance JsonEncode t Int                                              where mkEncoder = Tagged E.int
 instance JsonEncode t Scientific                                       where mkEncoder = Tagged E.scientific
 instance JsonEncode t Bool                                             where mkEncoder = Tagged E.bool
+instance JsonEncode t Json                                             where mkEncoder = Tagged E.json
 
 -- |
 -- Decoding Typeclass for Waargonaut
@@ -392,6 +395,7 @@ instance JsonDecode t Text                                             where mkD
 instance JsonDecode t Int                                              where mkDecoder = Tagged D.int
 instance JsonDecode t Scientific                                       where mkDecoder = Tagged D.scientific
 instance JsonDecode t Bool                                             where mkDecoder = Tagged D.bool
+instance JsonDecode t Json                                             where mkDecoder = Tagged D.json
 
 type JTag = String
 

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -349,8 +349,6 @@ class JsonEncode t a where
   mkEncoder =
     gEncoder defaultOpts
 
-
-
 instance JsonEncode t a                   => JsonEncode t (Maybe a)    where mkEncoder = E.maybeOrNull <$> mkEncoder
 instance (JsonEncode t a, JsonEncode t b) => JsonEncode t (Either a b) where mkEncoder = E.either <$> mkEncoder <*> mkEncoder
 instance (JsonEncode t a)                 => JsonEncode t [a]          where mkEncoder = E.list <$> mkEncoder

--- a/src/Waargonaut/Prettier.hs
+++ b/src/Waargonaut/Prettier.hs
@@ -11,6 +11,9 @@ module Waargonaut.Prettier
     -- * Functions
   , prettyJson
   , simpleEncodePretty
+
+    -- * Rexports
+  , module Natural
   ) where
 
 import           Prelude                              (Eq, Show, (+), (-))
@@ -77,6 +80,12 @@ newtype IndentStep = IndentStep Natural
 -- | Encode an @a@ directly to a 'ByteString' using the provided 'Encoder', the
 -- output will have newlines and indentation added based on the 'InlineOption' and
 -- 'NumSpaces'.
+--
+-- @
+-- let two = successor' $ successor' zero'
+-- simpleEncodePretty ArrayOnly (IndentStep two) (NumSpaces two) myEncoder myVal
+-- @
+--
 simpleEncodePretty
   :: Applicative f
   => InlineOption
@@ -132,7 +141,8 @@ prettyCommaSep csWrapper nested inline step w =
 -- increasing that indentation by two spaces for each nested object or array.
 --
 -- @
--- prettyJson ArrayOnly 2 2 j
+-- let two = successor' $ successor' zero'
+-- prettyJson ArrayOnly (IndentStep two) (NumSpaces two) j
 -- @
 --
 prettyJson :: InlineOption -> IndentStep -> NumSpaces -> Json -> Json

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.6.1.0
+version:             0.6.2.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.6.1.0";
+  version = "0.6.2.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
Added identity instances for encoding/decoding `Json`.

Fixed up the docs for Prettier module to correctly display that you
can't just provide raw numbers to those functions anymore.

Rexport the `Natural` module to provide the functions and types that
people will need.