### PR TITLE
Add gObjEncoder, fix some encoder bugs

### DIFF
--- a/src/Waargonaut/Decode/Internal.hs
+++ b/src/Waargonaut/Decode/Internal.hs
@@ -97,9 +97,6 @@ import           Waargonaut.Decode.Error         (AsDecodeError (..),
                                                   DecodeError (..))
 import           Waargonaut.Decode.ZipperMove    (ZipperMove (..), ppZipperMove)
 
-import           Waargonaut.Encode.Builder       (bsBuilder)
-import           Waargonaut.Encode.Builder.JChar (jCharBuilder)
--- |
 -- Track the history of the cursor as we move around the zipper.
 --
 -- It is indexed over the type of the index used to navigate the zipper.

--- a/src/Waargonaut/Encode.hs
+++ b/src/Waargonaut/Encode.hs
@@ -190,6 +190,7 @@ module Waargonaut.Encode
   , keyValuesAsObj'
   , json'
   , asJson'
+  , onObj'
   , generaliseEncoder
   ) where
 
@@ -848,6 +849,16 @@ onObj
   -> f (JObject WS Json)
 onObj k b encB o = (\j -> o & _Wrapped L.%~ L.cons j)
   . JAssoc (_JStringText # k) mempty mempty <$> asJson encB b
+
+-- | As per 'onObj' but the @f@ is specialised to 'Identity'.
+onObj'
+  :: Text
+  -> b
+  -> Encoder' b
+  -> JObject WS Json
+  -> JObject WS Json
+onObj' k b encB o = (\j -> o & _Wrapped L.%~ L.cons j)
+  . JAssoc (_JStringText # k) mempty mempty $ asJson' encB b
 
 -- | Encode key value pairs as a JSON object, allowing duplicate keys.
 keyValuesAsObj

--- a/src/Waargonaut/Encode/Builder.hs
+++ b/src/Waargonaut/Encode/Builder.hs
@@ -15,6 +15,7 @@ import qualified Data.Text.Lazy.Builder.Int        as T
 
 import           Data.ByteString                   (ByteString)
 import qualified Data.ByteString.Builder           as B
+import qualified Data.ByteString.Builder.Prim      as BP
 
 import           Waargonaut.Types.Json             (JType (..), Json (..))
 import           Waargonaut.Types.Whitespace       (WS)
@@ -35,7 +36,7 @@ textBuilder = Builder
 -- | A 'B.ByteString' builder
 bsBuilder :: Builder ByteString B.Builder
 bsBuilder = Builder
-  B.charUtf8
+  (BP.primBounded BP.charUtf8)-- B.charUtf8
   B.byteString
   B.intDec
 

--- a/src/Waargonaut/Encode/Builder.hs
+++ b/src/Waargonaut/Encode/Builder.hs
@@ -36,7 +36,7 @@ textBuilder = Builder
 -- | A 'B.ByteString' builder
 bsBuilder :: Builder ByteString B.Builder
 bsBuilder = Builder
-  (BP.primBounded BP.charUtf8)-- B.charUtf8
+  (BP.primBounded BP.charUtf8)
   B.byteString
   B.intDec
 

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -54,19 +54,20 @@ module Waargonaut.Generic
   ) where
 
 import           Generics.SOP
-import           Generics.SOP.Record (IsRecord)
+import           Generics.SOP.Record           (IsRecord)
 
-import           Control.Lens                  (findOf, folded, isn't, _Left, _Empty, (#))
+import           Control.Lens                  (findOf, folded, isn't, ( # ),
+                                                _Empty, _Left)
 import           Control.Monad                 ((>=>))
 import           Control.Monad.Except          (lift, throwError)
 import           Control.Monad.Reader          (runReaderT)
 import           Control.Monad.State           (modify)
 
-import Data.Function ((&))
 import qualified Data.Char                     as Char
+import           Data.Function                 ((&))
 import           Data.Maybe                    (fromMaybe)
 
-import Data.Foldable (foldl')
+import           Data.Foldable                 (foldl')
 
 import           Data.List.NonEmpty            (NonEmpty)
 
@@ -570,7 +571,8 @@ gObjEncoder opts = Tagged . E.objEncoder $ \a -> hcollapse $ hcliftA2
       E.onObj' (Text.pack t) (E.asJson' (T.proxy mkEncoder pt) a) E.json (_Empty # ())
 
     -- IsRecord constraint should make this impossible.
-    createObject _ _ = error "impossible?"
+    createObject _ _ =
+      error "The impossible has happened. Please report this as a bug: https://github.com/qfpl/waargonaut"
 
     toObj :: JsonEncode t x => K Text x -> I x -> K (JObject WS Json -> JObject WS Json) x
     toObj f a = K $ E.onObj' (unK f) (E.asJson' (T.proxy mkEncoder pt) (unI a)) E.json

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -523,6 +523,24 @@ gEncoder opts = Tagged . E.encodeA $ \a -> hcollapse $ hcliftA2
     pjE = Proxy :: Proxy (JsonEncode t)
     pt  = Proxy :: Proxy t
 
+-- | Create a 'Tagged' 'ObjEncoder' for type @ a @, tagged by @ t @.
+--
+-- This isn't compatible with the 'JsonEncode' typeclass because it creates an
+-- 'ObjEncoder' and for consistency reasons the 'JsonEncode' typeclass produces
+-- 'Encoder's.
+--
+-- However it lets you more easily access the 'Data.Functor.Contravariant.Contravariant'
+-- functionality that is part of the 'ObjEncoder' type.
+--
+-- @
+-- data Foo = Foo { fooA :: Text, fooB :: Int } deriving (Eq, Show)
+-- deriveGeneric ''Foo
+--
+-- objEncFoo :: Applicative f => ObjEncoder f Foo
+-- objEncFoo = untag $ gObjEncoder (defaultOps { _optionsFieldName = drop 3 })
+--
+-- @
+--
 gObjEncoder
   :: forall t a f xs.
      ( Generic a

--- a/src/Waargonaut/Generic.hs
+++ b/src/Waargonaut/Generic.hs
@@ -542,6 +542,9 @@ gEncoder opts = Tagged . E.encodeA $ \a -> hcollapse $ hcliftA2
 --
 -- @
 --
+-- NB: This function overrides the newtype options to use the 'FieldNameAsKey' option to
+-- be consistent with the behaviour of the record encoding.
+--
 gObjEncoder
   :: forall t a f xs.
      ( Generic a

--- a/src/Waargonaut/Types/JChar/Escaped.hs
+++ b/src/Waargonaut/Types/JChar/Escaped.hs
@@ -47,7 +47,7 @@ import           Waargonaut.Types.JChar.HexDigit4 (HexDigit4, charToHexDigit4,
                                                    hexDigit4ToChar,
                                                    parseHexDigit4)
 import           Waargonaut.Types.Whitespace      (Whitespace (..),
-                                                   unescapedWhitespaceChar,
+                                                   escapedWhitespaceChar,
                                                    _WhitespaceChar)
 
 -- $setup
@@ -184,7 +184,7 @@ escapedToChar = \case
   ReverseSolidus -> '\\'
   Solidus        -> '/'
   Backspace      -> '\b'
-  WhiteSpace wc  -> unescapedWhitespaceChar wc
+  WhiteSpace wc  -> escapedWhitespaceChar wc
   Hex hd         -> hexDigit4ToChar hd
 
 -- | Attempt to convert a Haskell 'Char' to an 'Escaped' JSON character

--- a/test/Generics.hs
+++ b/test/Generics.hs
@@ -1,0 +1,31 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Generics
+  ( genericsTests
+  ) where
+
+import           Test.Tasty         (TestTree, testGroup)
+import           Test.Tasty.HUnit   (Assertion, testCase, (@?=))
+
+import           Waargonaut.Encode  (Encoder)
+import qualified Waargonaut.Encode  as E
+
+import qualified Types.Common       as C
+
+import qualified Waargonaut.Generic as G
+
+testGenericFieldNameFunctionUsedOnce :: Assertion
+testGenericFieldNameFunctionUsedOnce = do
+  let
+    encFudge :: Applicative f => Encoder f C.Fudge
+    encFudge = G.untag . G.gEncoder $ C.fudgeJsonOpts
+      { G._optionsFieldName = tail
+      }
+
+    expected = "{\"udge\":\"Chocolate\"}"
+
+  E.simplePureEncodeTextNoSpaces encFudge C.testFudge @?= expected
+
+genericsTests :: TestTree
+genericsTests = testGroup "Generics"
+  [ testCase "Options fieldName function is used only once" testGenericFieldNameFunctionUsedOnce
+  ]

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -31,6 +31,7 @@ import qualified Decoder.Laws
 import qualified Encoder
 import qualified Encoder.Laws
 import qualified Golden
+import qualified Generics
 import qualified Json
 import qualified Properties
 
@@ -89,6 +90,8 @@ main = do
 
     , Decoder.decoderTests
     , Encoder.encoderTests
+
+    , Generics.genericsTests
 
     , goldens
     ]

--- a/test/Types/Common.hs
+++ b/test/Types/Common.hs
@@ -23,6 +23,7 @@ module Types.Common
 
   , testImageDataType
   , testFudge
+  , fudgeJsonOpts
   , imageDecodeGeneric
   , imageDecodeSuccinct
 
@@ -132,7 +133,7 @@ imageOpts = defaultOpts
 instance JsonEncode GWaarg Image where mkEncoder = gEncoder imageOpts
 instance JsonDecode GWaarg Image where mkDecoder = gDecoder imageOpts
 
-newtype Fudge = Fudge Text
+newtype Fudge = Fudge { unCrepe :: Text }
   deriving (Eq, Show, GHC.Generic)
 
 instance Generic Fudge

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -161,6 +161,7 @@ library
                      , containers              >= 0.5.6   && < 0.7
                      , witherable              >= 0.2     && < 0.4
                      , generics-sop            >= 0.4     && < 0.5
+                     , records-sop             >= 0.1     && < 0.2
                      , mmorph                  >= 1.1     && < 1.2
                      , transformers            >= 0.4     && < 0.6
                      , bifunctors              >= 5       && < 5.6
@@ -215,6 +216,7 @@ test-suite waarg-tests
                      , Prettier.NestedObjs
                      , Properties
                      , Golden
+                     , Generics
                      , Laws
                      , Utils
                      , Encoder

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.7.1.0
+version:             0.8.0.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.cabal
+++ b/waargonaut.cabal
@@ -10,7 +10,7 @@ name:                waargonaut
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.7.0.1
+version:             0.7.1.0
 
 -- A short (one-line) description of the package.
 synopsis:            JSON wrangling

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -3,23 +3,23 @@
 , distributive, doctest, errors, filepath, generics-sop, hedgehog
 , hedgehog-fn, hoist-error, hw-balancedparens, hw-bits
 , hw-json-standard-cursor, hw-prim, hw-rankselect, lens, mmorph
-, mtl, nats, natural, parsers, scientific, semigroupoids
-, semigroups, stdenv, tagged, tasty, tasty-expected-failure
-, tasty-golden, tasty-hedgehog, tasty-hunit, template-haskell, text
-, transformers, unordered-containers, vector, witherable
-, wl-pprint-annotated, zippers
+, mtl, nats, natural, parsers, records-sop, scientific
+, semigroupoids, semigroups, stdenv, tagged, tasty
+, tasty-expected-failure, tasty-golden, tasty-hedgehog, tasty-hunit
+, template-haskell, text, transformers, unordered-containers
+, vector, witherable, wl-pprint-annotated, zippers
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.7.0.0";
+  version = "0.7.0.1";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [
     attoparsec base bifunctors bytestring containers contravariant
     digit distributive errors generics-sop hoist-error
     hw-balancedparens hw-bits hw-json-standard-cursor hw-prim
-    hw-rankselect lens mmorph mtl nats natural parsers scientific
-    semigroupoids semigroups tagged text transformers
+    hw-rankselect lens mmorph mtl nats natural parsers records-sop
+    scientific semigroupoids semigroups tagged text transformers
     unordered-containers vector witherable wl-pprint-annotated zippers
   ];
   testHaskellDepends = [

--- a/waargonaut.nix
+++ b/waargonaut.nix
@@ -11,7 +11,7 @@
 }:
 mkDerivation {
   pname = "waargonaut";
-  version = "0.7.0.1";
+  version = "0.8.0.0";
   src = ./.;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [


### PR DESCRIPTION
Add `onObj'` which is just `onObj` but specialised to `Identity`.

Add `gObjEncoder` for deriving `ObjEncoder` structures for record types only. Using the
`IsRecord` constraint from `record-sop` package. This makes it easier to leverage the
Contravariant functionality of the `ObjEncoder` without losing the benefits of deriving
more trivial encoders.

Added the `FieldNameAsKey` option to the newtype options for generic derived enc/decoders.

Fixes #69  by removing duplicate call to `_optionsFieldName` function. Added regression
test.

Improved the handling of newtype options for generic deriving to give a bit more
flexibility and avoid strangeness wrt to some combinations of options.

Change the building of escaped whitespace chars to actually use the
`escapedWhitespaceChar` function, instead of incorrectly generating an unescaped
character.